### PR TITLE
One-line installer + full Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sepia
 
+**English** | [繁體中文](README.zh-TW.md)
+
 > De-AI writing at the layer that actually gives AI away. Fiction gets its narrative architecture repaired before anyone touches word choice; professional documents (release notes, PR replies, postmortems, tickets, technical articles) each get rules matched to their venue.
 
 A portable [Agent Skill](https://agentskills.io/specification) for Claude Code, Codex, Grok Build, and Antigravity. One canonical `SKILL.md`, no per-platform forks. Four operations: **write**, **review** (diagnose only), **refactor** (minimal edits), **recreate** (full rewrite).
@@ -90,12 +92,6 @@ sepia/
 ├── install.sh
 └── research/                # digested evidence base with sources
 ```
-
-## 中文說明
-
-sepia 是一個去 AI 味的寫作 skill。小說模式不從詞彙下手：StoryScope 證實真正暴露 AI 身分的是敘事架構——主題講得太白、情節單線到底、情緒全靠身體感官、時間永遠線性、結局收得乾乾淨淨。先修這一層，再輪到篇章與字句；內含 30 特徵診斷 rubric 與各模型指紋表。
-
-專業文書（release 公告、PR/issue 回覆、postmortem、工單、技術文章）各有自己的規則檔，核心是同一件事：對齊 venue 的語域、每個宣稱附上真實 artifact、該下判斷的地方下判斷。支援 write／review（只診斷）／refactor（最小修改）／recreate（重寫）四種操作。校準原則：往人類分布的中間帶靠；把 AI 特徵反轉到極端，只會做出新的指紋。
 
 ## Sources
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ Grok Build auto-discovers Claude Code's plugins, so this install covers Grok use
 
 **Grok Build without Claude Code:** run `./install.sh` (links into Grok's native `~/.grok/skills/`), or add `Nanako0129/sepia` as a marketplace source in Grok's Marketplace tab — Grok consumes Claude Code marketplace repos directly.
 
-**All four platforms at once:**
+**All four platforms, one line:**
 
 ```bash
-git clone https://github.com/Nanako0129/sepia.git ~/.sepia
-~/.sepia/install.sh
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
 ```
 
-`install.sh` installs at user scope only:
+This clones the repo to `~/.sepia` (override with `SEPIA_HOME`) and installs at user scope; re-run the same line to update everything. Prefer to inspect first? Clone it yourself and run `./install.sh` from the checkout — same result. Either way it installs:
 
 | Platform | Where | Mechanism |
 |---|---|---|
@@ -68,8 +67,6 @@ git clone https://github.com/Nanako0129/sepia.git ~/.sepia
 | Codex | `~/.agents/skills/sepia` | symlink |
 | Grok Build | `~/.grok/skills/sepia` (native path, no Claude Code needed) | symlink |
 | Antigravity | `~/.gemini/config/skills/sepia` + `/sepia` global workflow | copy |
-
-Keep the clone — the symlinks point into it. `git pull` updates Claude Code, Grok, and Codex in place; re-run `install.sh` after pulling to refresh the Antigravity copy.
 
 **Project scope (alternative):** when one repo should pin its own copy, commit `skills/sepia/` into that repo as `.agents/skills/sepia` (Codex + Antigravity) or `.claude/skills/sepia` (Claude Code).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,102 @@
+# sepia
+
+[English](README.md) | **繁體中文**
+
+> 在真正洩底的那一層去 AI 味。小說先修敘事架構，再碰字句；專業文件（release 公告、PR 回覆、postmortem、工單、技術文章）各自套用貼合 venue 的規則。
+
+可攜的 [Agent Skill](https://agentskills.io/specification)，支援 Claude Code、Codex、Grok Build、Antigravity。一份 canonical `SKILL.md`，不為平台分叉。四種操作：**write**、**review**（只診斷）、**refactor**（最小修改）、**recreate**（整篇重寫）。
+
+## 為什麼還需要另一個 humanizer
+
+市面上的 humanizer 都在改用詞與句法。[StoryScope](https://arxiv.org/abs/2604.03136)（Russell et al., 2026：61,608 篇故事，人類＋5 個前緣 LLM）證明：只用**敘事結構特徵**的分類器就能以 93.2% macro-F1 偵測 AI 小說，而把表面風格洗掉幾乎不影響偵測率（95.5% → 93.9%）。留下來的破綻全是架構性的：敘事者把主題講明、因果整齊的單線情節、情緒只用身體感官呈現、不引用真實世界、無視讀者、時間全程線性、結局靠主角的成長與釋懷收束。
+
+sepia 把這些量化落差，連同 [`research/`](research/) 裡消化過的十一篇相關研究，整理成小說寫作與改稿的三段 pass：
+
+| Pass | 層次 | 例子 |
+|---|---|---|
+| 1 | 敘事架構（小說） | 別解釋主題、鬆開因果鏈、把揭露往後放、混用情緒表達模式、稀疏的角色網絡、指名真實事物 |
+| 2 | 篇章推進 | 拆掉段落問題序列的模板、修中段鬆垮、變化節奏與位置 |
+| 3 | 表面風格 | 經典層：cliché、句法模板、詞彙、語域 |
+
+另附 30 特徵診斷 rubric 與各模型指紋校正表（Claude、GPT、Gemini、DeepSeek、Kimi）。
+
+專業文書壞的方式不一樣。研究指向的是：不帶資訊的填充、該下判斷時的閃躲、chatbot 殘留、無視 venue 的語域、蓋章式的整齊格式。每種文件型態在一份共用 checklist 之上各配一個精簡規則檔：
+
+| 領域 | 要點 |
+|---|---|
+| Release 公告 | 使用者衝擊優先、每個宣稱附 artifact、不灌行銷詞 |
+| PR／issue 回覆 | 第一句就是答案、引 `file:line`、不反射性稱讚、篇幅與 stakes 成比例 |
+| Postmortem | 對人 blameless、對機制不留情；時間戳、死路、有主的 action items |
+| 工單 | 標題＝結果、驗收條件可測試、能連結就不重複 |
+| 技術文章 | 從問題開場、至少一條真實死路、敢下一個判斷、數字附條件 |
+
+貫穿全部的原則：**校準到人類分布，而不是把 AI 特徵反著做。**人類落在中間值；一篇把所有規則用好用滿的故事，只是另一種指紋。skill 每篇挑 3–5 個手法，其餘留白。
+
+## 安裝
+
+預設 **user scope**——裝一次，每個專案都能用。下列 CLI 路徑本身就是 user scope；session 內的 `/plugin install` 對話框會要你選 scope，記得選 **User**。
+
+**Skills CLI（77+ 個 agent，執行時選你的）：**
+
+```bash
+npx skills add Nanako0129/sepia -g
+```
+
+`-g` 才是 user scope（預設是 project）。之後用 `npx skills update -g` 更新。
+
+**Claude Code plugin（Grok Build 順帶生效）：**
+
+```bash
+claude plugin marketplace add Nanako0129/sepia
+claude plugin install sepia@sepia --scope user
+```
+
+Grok Build 會自動探索 Claude Code 的 plugin，所以同時用 Claude Code 的 Grok 使用者裝這份就夠。
+
+**沒有 Claude Code 的 Grok Build：**跑 `./install.sh`（鏈進 Grok 原生的 `~/.grok/skills/`），或在 Grok 的 Marketplace 分頁直接加 `Nanako0129/sepia`——Grok 可直接使用 Claude Code 格式的 marketplace repo。
+
+**四平台一行裝完：**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
+```
+
+這行會把 repo clone 到 `~/.sepia`（可用 `SEPIA_HOME` 覆寫）並以 user scope 安裝；重跑同一行就是更新。想先看內容再跑？自己 clone 下來，從 checkout 執行 `./install.sh`，結果相同。兩種方式裝出來都是：
+
+| 平台 | 位置 | 機制 |
+|---|---|---|
+| Claude Code | `~/.claude/skills/sepia` | symlink |
+| Codex | `~/.agents/skills/sepia` | symlink |
+| Grok Build | `~/.grok/skills/sepia`（原生路徑，不需要 Claude Code） | symlink |
+| Antigravity | `~/.gemini/config/skills/sepia` ＋ `/sepia` global workflow | copy |
+
+**Project scope（替代方案）：**當某個 repo 需要釘住自己的版本時，把 `skills/sepia/` commit 進該 repo 的 `.agents/skills/sepia`（Codex＋Antigravity）或 `.claude/skills/sepia`（Claude Code）。
+
+## 目錄結構
+
+```text
+sepia/
+├── skills/sepia/            # canonical skill (Agent Skills standard)
+│   ├── SKILL.md             # routing, operations, calibration rules, guardrails
+│   └── references/
+│       ├── narrative-pass.md      # fiction pass 1: architecture (the differentiator)
+│       ├── discourse-pass.md      # pass 2: paragraph-level flow
+│       ├── style-pass.md          # pass 3: surface style
+│       ├── rubric.md              # fiction 30-feature diagnosis
+│       ├── model-fingerprints.md  # per-model corrections
+│       ├── professional-pass.md   # shared non-fiction layer (slop checklist, venue matching)
+│       └── domains/               # release-notes, dev-replies, postmortems, tickets, tech-articles
+├── .claude-plugin/          # Claude Code packaging (plugin.json, marketplace.json)
+├── .codex-plugin/           # Codex packaging
+├── .agents/                 # Codex/Antigravity workspace-mode discovery + Antigravity workflow
+├── install.sh
+└── research/                # digested evidence base with sources
+```
+
+## 資料來源
+
+完整摘要與連結見 [`research/`](research/)。主要文獻：StoryScope（[arXiv:2604.03136](https://arxiv.org/abs/2604.03136)）、LAMP（[CHI 2025](https://arxiv.org/abs/2409.14509)）、Measuring AI Slop（[arXiv:2509.19163](https://arxiv.org/abs/2509.19163)）、Reinhart et al.（[PNAS 2025](https://arxiv.org/abs/2410.16107)）、Russell et al.（[ACL 2025](https://arxiv.org/abs/2501.15654)）、NarraBench（[arXiv:2510.09869](https://arxiv.org/abs/2510.09869)）、Echoes in AI（[PNAS 2025](https://arxiv.org/abs/2501.00273)）、QUDsim（[COLM 2025](https://arxiv.org/abs/2504.09373)）、Beguš（[2024](https://arxiv.org/abs/2310.12902)）、Beyond Checkmate（[EMNLP 2025](https://arxiv.org/abs/2501.19301)）、Nonaka & Perry（[2025](https://arxiv.org/abs/2510.18932)）、Chakrabarty et al.（[2026](https://arxiv.org/abs/2510.13939)）。
+
+## 授權
+
+MIT

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,29 @@
 # Installs the sepia skill at USER scope for Claude Code, Codex, Grok Build,
 # and Antigravity. Claude Code / Codex / Grok follow symlinks; Antigravity
 # gets a copy. For project-scope installs, see README.md.
+#
+# One-liner (clones to ~/.sepia, or $SEPIA_HOME, then installs):
+#   curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
+# Re-run the same line to update everything.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO_URL="${SEPIA_REPO:-https://github.com/Nanako0129/sepia.git}"
+CLONE_DIR="${SEPIA_HOME:-$HOME/.sepia}"
+
+# Piped via curl (or run outside a checkout): clone/update first, then re-exec
+# from the clone so the symlinks have a permanent target.
+SCRIPT_SRC="${BASH_SOURCE[0]:-}"
+if [ -z "$SCRIPT_SRC" ] || [ ! -f "$(cd "$(dirname "$SCRIPT_SRC")" 2>/dev/null && pwd)/skills/sepia/SKILL.md" ]; then
+  if [ -d "$CLONE_DIR/.git" ]; then
+    echo "updating $CLONE_DIR"
+    git -C "$CLONE_DIR" pull --ff-only
+  else
+    git clone "$REPO_URL" "$CLONE_DIR"
+  fi
+  exec bash "$CLONE_DIR/install.sh"
+fi
+
+ROOT="$(cd "$(dirname "$SCRIPT_SRC")" && pwd)"
 SKILL="$ROOT/skills/sepia"
 
 link() {
@@ -37,6 +57,6 @@ echo "  Codex       : ~/.agents/skills/sepia (symlink)"
 echo "  Grok Build  : ~/.grok/skills/sepia (symlink)"
 echo "  Antigravity : ~/.gemini/config/skills/sepia (copy) + /sepia workflow"
 echo ""
-echo "Keep this clone: the symlinks point into it. 'git pull' updates the"
-echo "symlinked installs; re-run install.sh after pulling to refresh the"
-echo "Antigravity copy."
+echo "Keep this clone: the symlinks point into it. To update everything,"
+echo "re-run the install one-liner (or 'git pull' here, then re-run"
+echo "install.sh to refresh the Antigravity copy)."


### PR DESCRIPTION
Two changes, both follow-ups to install-guidance feedback:

**feat(install): one-line curl installer** — `install.sh` now bootstraps its own clone when piped (`curl -fsSL .../install.sh | bash`): clones to `~/.sepia` (overridable via `SEPIA_HOME`, source via `SEPIA_REPO`), or fast-forward-pulls an existing clone, then re-execs itself from the clone so the user-scope symlinks have a permanent target. Run from a checkout it behaves as before. Verified in a sandbox HOME: piped install, checkout-mode install, and re-run update all pass.

**docs: Chinese README as a peer document** — the condensed 中文說明 section is replaced by `README.zh-TW.md`, a section-by-section mirror of the English README (same install commands with explicit scope flags, same tables); both files link to each other at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwGKATJ6u4rgWyLsbg4Grj