### PR TITLE
Per-platform native install + update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,43 +34,88 @@ The governing principle throughout: **calibrate to the human distribution, don't
 
 ## Install
 
-Default is **user scope** — install once, and the skill follows you into every project. The CLI routes below are user-scope out of the box; the in-session `/plugin install` dialog instead asks you to pick a scope, so choose **User** there.
+Every platform has its own native install, each paired with its update commands. Default everywhere is **user scope** — install once, use it in every project.
 
-**Skills CLI (77+ agents, pick yours when prompted):**
-
-```bash
-npx skills add Nanako0129/sepia -g
-```
-
-`-g` is what makes it user scope (the default is project). Update later with `npx skills update -g`.
-
-**Claude Code plugin (Grok Build rides along):**
+### Claude Code
 
 ```bash
+# install
 claude plugin marketplace add Nanako0129/sepia
 claude plugin install sepia@sepia --scope user
+
+# update
+claude plugin marketplace update sepia
+claude plugin update sepia
 ```
 
-Grok Build auto-discovers Claude Code's plugins, so this install covers Grok users who also run Claude Code.
+The in-session `/plugin install` dialog asks you to pick a scope — choose **User** there.
 
-**Grok Build without Claude Code:** run `./install.sh` (links into Grok's native `~/.grok/skills/`), or add `Nanako0129/sepia` as a marketplace source in Grok's Marketplace tab — Grok consumes Claude Code marketplace repos directly.
+### Codex
 
-**All four platforms, one line:**
+```bash
+# install
+codex plugin marketplace add Nanako0129/sepia
+codex plugin add sepia@sepia
+
+# update — refresh the marketplace snapshot, then re-add to pick up the new version
+codex plugin marketplace upgrade sepia
+codex plugin add sepia@sepia
+```
+
+### Grok Build
+
+```bash
+# install
+grok plugin install Nanako0129/sepia --trust
+
+# update
+grok plugin update
+```
+
+Grok also auto-discovers a Claude Code install of sepia if you have one; either route works.
+
+### Antigravity
+
+No marketplace here — the native install is placing the skill folder, plus the `/sepia` slash workflow:
+
+```bash
+# install
+git clone https://github.com/Nanako0129/sepia.git ~/.sepia
+mkdir -p ~/.gemini/config/skills ~/.gemini/antigravity/global_workflows
+cp -R ~/.sepia/skills/sepia ~/.gemini/config/skills/sepia
+cp ~/.sepia/.agents/workflows/sepia.md ~/.gemini/antigravity/global_workflows/sepia.md
+
+# update
+git -C ~/.sepia pull
+rm -rf ~/.gemini/config/skills/sepia && cp -R ~/.sepia/skills/sepia ~/.gemini/config/skills/sepia
+cp ~/.sepia/.agents/workflows/sepia.md ~/.gemini/antigravity/global_workflows/sepia.md
+```
+
+### All four at once (alternative)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
 ```
 
-This clones the repo to `~/.sepia` (override with `SEPIA_HOME`) and installs at user scope; re-run the same line to update everything. Prefer to inspect first? Clone it yourself and run `./install.sh` from the checkout — same result. Either way it installs:
+Clones the repo to `~/.sepia` (override with `SEPIA_HOME`) and installs at user scope for all four platforms; re-running the same line is also the update. Prefer to inspect first? Clone it yourself and run `./install.sh` from the checkout. Either way it installs:
 
 | Platform | Where | Mechanism |
 |---|---|---|
 | Claude Code | `~/.claude/skills/sepia` | symlink |
 | Codex | `~/.agents/skills/sepia` | symlink |
-| Grok Build | `~/.grok/skills/sepia` (native path, no Claude Code needed) | symlink |
+| Grok Build | `~/.grok/skills/sepia` | symlink |
 | Antigravity | `~/.gemini/config/skills/sepia` + `/sepia` global workflow | copy |
 
-**Project scope (alternative):** when one repo should pin its own copy, commit `skills/sepia/` into that repo as `.agents/skills/sepia` (Codex + Antigravity) or `.claude/skills/sepia` (Claude Code).
+### Skills CLI (alternative, 77+ agents)
+
+```bash
+npx skills add Nanako0129/sepia -g     # -g = user scope; the default is project
+npx skills update -g                   # update
+```
+
+### Project scope (alternative)
+
+When one repo should pin its own copy, commit `skills/sepia/` into that repo as `.agents/skills/sepia` (Codex + Antigravity) or `.claude/skills/sepia` (Claude Code).
 
 ## Layout
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -34,43 +34,88 @@ sepia 把這些量化落差，連同 [`research/`](research/) 裡消化過的十
 
 ## 安裝
 
-預設 **user scope**——裝一次，每個專案都能用。下列 CLI 路徑本身就是 user scope；session 內的 `/plugin install` 對話框會要你選 scope，記得選 **User**。
+每個平台都有自己的原生安裝方式，並各自配對更新指令。全部預設 **user scope**——裝一次，每個專案都能用。
 
-**Skills CLI（77+ 個 agent，執行時選你的）：**
-
-```bash
-npx skills add Nanako0129/sepia -g
-```
-
-`-g` 才是 user scope（預設是 project）。之後用 `npx skills update -g` 更新。
-
-**Claude Code plugin（Grok Build 順帶生效）：**
+### Claude Code
 
 ```bash
+# 安裝
 claude plugin marketplace add Nanako0129/sepia
 claude plugin install sepia@sepia --scope user
+
+# 更新
+claude plugin marketplace update sepia
+claude plugin update sepia
 ```
 
-Grok Build 會自動探索 Claude Code 的 plugin，所以同時用 Claude Code 的 Grok 使用者裝這份就夠。
+session 內的 `/plugin install` 對話框會要你選 scope——記得選 **User**。
 
-**沒有 Claude Code 的 Grok Build：**跑 `./install.sh`（鏈進 Grok 原生的 `~/.grok/skills/`），或在 Grok 的 Marketplace 分頁直接加 `Nanako0129/sepia`——Grok 可直接使用 Claude Code 格式的 marketplace repo。
+### Codex
 
-**四平台一行裝完：**
+```bash
+# 安裝
+codex plugin marketplace add Nanako0129/sepia
+codex plugin add sepia@sepia
+
+# 更新——先刷新 marketplace 快照，再重跑 add 換上新版本
+codex plugin marketplace upgrade sepia
+codex plugin add sepia@sepia
+```
+
+### Grok Build
+
+```bash
+# 安裝
+grok plugin install Nanako0129/sepia --trust
+
+# 更新
+grok plugin update
+```
+
+若你同時裝了 Claude Code 版的 sepia，Grok 也會自動探索到；兩條路都通。
+
+### Antigravity
+
+這裡沒有 marketplace——原生安裝就是放置 skill 資料夾，外加 `/sepia` slash workflow：
+
+```bash
+# 安裝
+git clone https://github.com/Nanako0129/sepia.git ~/.sepia
+mkdir -p ~/.gemini/config/skills ~/.gemini/antigravity/global_workflows
+cp -R ~/.sepia/skills/sepia ~/.gemini/config/skills/sepia
+cp ~/.sepia/.agents/workflows/sepia.md ~/.gemini/antigravity/global_workflows/sepia.md
+
+# 更新
+git -C ~/.sepia pull
+rm -rf ~/.gemini/config/skills/sepia && cp -R ~/.sepia/skills/sepia ~/.gemini/config/skills/sepia
+cp ~/.sepia/.agents/workflows/sepia.md ~/.gemini/antigravity/global_workflows/sepia.md
+```
+
+### 四平台一次裝完（替代方案）
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
 ```
 
-這行會把 repo clone 到 `~/.sepia`（可用 `SEPIA_HOME` 覆寫）並以 user scope 安裝；重跑同一行就是更新。想先看內容再跑？自己 clone 下來，從 checkout 執行 `./install.sh`，結果相同。兩種方式裝出來都是：
+這行會把 repo clone 到 `~/.sepia`（可用 `SEPIA_HOME` 覆寫）並以 user scope 安裝四個平台；重跑同一行就是更新。想先看內容再跑？自己 clone 下來，從 checkout 執行 `./install.sh`。兩種方式裝出來都是：
 
 | 平台 | 位置 | 機制 |
 |---|---|---|
 | Claude Code | `~/.claude/skills/sepia` | symlink |
 | Codex | `~/.agents/skills/sepia` | symlink |
-| Grok Build | `~/.grok/skills/sepia`（原生路徑，不需要 Claude Code） | symlink |
+| Grok Build | `~/.grok/skills/sepia` | symlink |
 | Antigravity | `~/.gemini/config/skills/sepia` ＋ `/sepia` global workflow | copy |
 
-**Project scope（替代方案）：**當某個 repo 需要釘住自己的版本時，把 `skills/sepia/` commit 進該 repo 的 `.agents/skills/sepia`（Codex＋Antigravity）或 `.claude/skills/sepia`（Claude Code）。
+### Skills CLI（替代方案，77+ 個 agent）
+
+```bash
+npx skills add Nanako0129/sepia -g     # -g 才是 user scope；預設是 project
+npx skills update -g                   # 更新
+```
+
+### Project scope（替代方案）
+
+當某個 repo 需要釘住自己的版本時，把 `skills/sepia/` commit 進該 repo 的 `.agents/skills/sepia`（Codex＋Antigravity）或 `.claude/skills/sepia`（Claude Code）。
 
 ## 目錄結構
 


### PR DESCRIPTION
Acceptance fix: every platform now has its own native install route paired with update commands, in both READMEs (English + zh-TW mirror).

- **Claude Code**: `claude plugin marketplace add` / `install --scope user`; update via `marketplace update` + `plugin update`
- **Codex**: `codex plugin marketplace add` + `codex plugin add sepia@sepia`; update via `marketplace upgrade` + re-add — **verified live** (installed enabled at 0.2.0 from the published repo)
- **Grok Build**: `grok plugin install Nanako0129/sepia --trust`; update via `grok plugin update` — **verified live**
- **Antigravity**: no marketplace exists; native = documented clone + cp of the skill and `/sepia` workflow, update = pull + re-copy (rm -rf first to avoid nested copies)

The curl one-liner, Skills CLI, and project-scope routes stay as labeled alternatives, each with its update line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwGKATJ6u4rgWyLsbg4Grj