### PR TITLE
Make the user-scope installer fail closed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,62 +1,409 @@
 #!/usr/bin/env bash
-# Installs the sepia skill at USER scope for Claude Code, Codex, Grok Build,
-# and Antigravity. Claude Code / Codex / Grok follow symlinks; Antigravity
-# gets a copy. For project-scope installs, see README.md.
-#
-# One-liner (clones to ~/.sepia, or $SEPIA_HOME, then installs):
-#   curl -fsSL https://raw.githubusercontent.com/Nanako0129/sepia/main/install.sh | bash
-# Re-run the same line to update everything.
+# Install or uninstall Sepia at user scope for Claude Code, Codex, Grok Build,
+# and Antigravity. See README.md for the SHA-pinned bootstrap command.
 set -euo pipefail
+umask 077
 
 REPO_URL="${SEPIA_REPO:-https://github.com/Nanako0129/sepia.git}"
-CLONE_DIR="${SEPIA_HOME:-$HOME/.sepia}"
-
-# Piped via curl (or run outside a checkout): clone/update first, then re-exec
-# from the clone so the symlinks have a permanent target.
+CLONE_DIR="${SEPIA_HOME:-${HOME:-}/.sepia}"
+REF="${SEPIA_REF:-}"
+ACTION="${SEPIA_ACTION:-install}"
+OWNER="sepia-installer-v1"
+STATE_NAME=".sepia-install-state"
+MANIFEST_NAME=".sepia-install-manifest"
 SCRIPT_SRC="${BASH_SOURCE[0]:-}"
-if [ -z "$SCRIPT_SRC" ] || [ ! -f "$(cd "$(dirname "$SCRIPT_SRC")" 2>/dev/null && pwd)/skills/sepia/SKILL.md" ]; then
-  if [ -d "$CLONE_DIR/.git" ]; then
-    echo "updating $CLONE_DIR"
-    git -C "$CLONE_DIR" pull --ff-only
-  else
-    git clone "$REPO_URL" "$CLONE_DIR"
-  fi
-  exec bash "$CLONE_DIR/install.sh"
-fi
 
-ROOT="$(cd "$(dirname "$SCRIPT_SRC")" && pwd)"
-SKILL="$ROOT/skills/sepia"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
 
-link() {
-  mkdir -p "$(dirname "$2")"
-  ln -sfn "$1" "$2"
-  echo "linked  $2"
+die() {
+  printf 'sepia installer: %s\n' "$*" >&2
+  exit 1
 }
 
-link "$SKILL" "$HOME/.claude/skills/sepia"   # Claude Code
-link "$SKILL" "$HOME/.agents/skills/sepia"   # Codex (user scope)
-link "$SKILL" "$HOME/.grok/skills/sepia"     # Grok Build native path — works with or without Claude Code installed
+collision() {
+  printf 'sepia installer: refusing to change %s: %s\n' "$1" "$2" >&2
+  printf 'Move the path aside, or restore its Sepia ownership metadata and installed content, then rerun. No destination was changed.\n' >&2
+  exit 1
+}
 
-# Antigravity global skills dir (copy: keep in sync by re-running install.sh)
+git_safe() {
+  git -c core.hooksPath=/dev/null -c core.fsmonitor=false "$@"
+}
+
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+validate_inputs() {
+  [ -n "${HOME:-}" ] || die 'HOME is empty'
+  case "$HOME" in /*) ;; *) die 'HOME must be an absolute path' ;; esac
+  [ "$HOME" != / ] || die 'HOME cannot be /'
+  [ -d "$HOME" ] && [ ! -L "$HOME" ] || die 'HOME must be a real directory, not a symlink'
+
+  case "$CLONE_DIR" in /*) ;; *) die 'SEPIA_HOME must be an absolute path' ;; esac
+  [ "$CLONE_DIR" != / ] && [ "$CLONE_DIR" != "$HOME" ] || die 'SEPIA_HOME is too broad'
+  case "$CLONE_DIR" in *$'\n'*) die 'SEPIA_HOME cannot contain a newline' ;; esac
+  case "$CLONE_DIR/" in *//*|*/./*|*/../*) die 'SEPIA_HOME must be a normalized path without //, ., or .. segments' ;; esac
+
+  [ -n "$REPO_URL" ] || die 'SEPIA_REPO is empty'
+  case "$REPO_URL" in -*|*$'\n'*) die 'SEPIA_REPO is invalid' ;; esac
+  case "$REPO_URL" in
+    https://*|ssh://*|git@*:*|file://*|/*) ;;
+    *) die 'SEPIA_REPO must use HTTPS, SSH, or an explicit local/file path' ;;
+  esac
+  [[ "$REF" =~ ^[0-9A-Fa-f]{40}$ ]] || die 'SEPIA_REF must be one full 40-hex commit SHA; branches and tags are not accepted'
+  REF="$(printf '%s' "$REF" | tr 'A-F' 'a-f')"
+  case "$ACTION" in install|uninstall) ;; *) die 'SEPIA_ACTION must be install or uninstall' ;; esac
+
+  command -v git >/dev/null 2>&1 || die 'git is required'
+  command -v awk >/dev/null 2>&1 || die 'awk is required'
+  command -v cmp >/dev/null 2>&1 || die 'cmp is required'
+  command -v find >/dev/null 2>&1 || die 'find is required'
+  command -v sort >/dev/null 2>&1 || die 'sort is required'
+  if ! command -v shasum >/dev/null 2>&1 && ! command -v sha256sum >/dev/null 2>&1; then
+    die 'shasum or sha256sum is required'
+  fi
+}
+
+verify_installer_entry() {
+  local root="$1" revision="$2" entry mode type oid path
+  entry="$(git_safe -C "$root" ls-tree "$revision" -- install.sh)"
+  read -r mode type oid path <<<"$entry"
+  [ "$mode" = 100755 ] && [ "$type" = blob ] && [ "$path" = install.sh ] ||
+    die "revision $revision does not contain install.sh as an executable regular file"
+  printf '%s\n' "$oid"
+}
+
+verify_running_installer() {
+  local root="$1" revision="$2" oid
+  oid="$(verify_installer_entry "$root" "$revision")"
+  [ "$(git_safe -C "$root" hash-object "$SCRIPT_SRC")" = "$oid" ]
+}
+
+verify_origin() {
+  local root="$1" origins
+  origins="$(git_safe -C "$root" config --local --get-all remote.origin.url || true)"
+  [ "$origins" = "$REPO_URL" ] || die "$root has a foreign or ambiguous origin; expected exactly $REPO_URL"
+}
+
+verify_clean_checkout() {
+  local root="$1" expected="$2" head oid
+  if [ -L "$root/.git" ] || { [ ! -d "$root/.git" ] && [ ! -f "$root/.git" ]; }; then
+    die "$root/.git has an unexpected type"
+  fi
+  git_safe -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$root is not a Git checkout"
+  verify_origin "$root"
+  [ -f "$root/install.sh" ] && [ ! -L "$root/install.sh" ] || die "$root/install.sh must be a regular file, not a symlink"
+  [ -z "$(git_safe -C "$root" status --porcelain=v1 --untracked-files=all)" ] ||
+    die "$root is dirty or contains untracked files; refusing to execute or replace its installer"
+  head="$(git_safe -C "$root" rev-parse 'HEAD^{commit}')"
+  [ "$head" = "$expected" ] || die "$root HEAD $head does not match SEPIA_REF $expected"
+  oid="$(verify_installer_entry "$root" "$expected")"
+  [ "$(git_safe -C "$root" hash-object install.sh)" = "$oid" ] || die "$root/install.sh does not match revision $expected"
+}
+
+snapshot_dir() {
+  local dir="$1" output="$2" list path hash status
+  list="$(mktemp "${TMPDIR:-/tmp}/sepia-list.XXXXXX")"
+  : >"$output"
+  (
+    cd "$dir"
+    find . -mindepth 1 ! -path "./$STATE_NAME" ! -path "./$MANIFEST_NAME" -print | LC_ALL=C sort >"$list"
+    while IFS= read -r path; do
+      if [ -L "$path" ]; then
+        return 1
+      elif [ -d "$path" ]; then
+        printf 'd  %s\n' "$path" >>"$output"
+      elif [ -f "$path" ]; then
+        hash="$(sha256_file "$path")"
+        printf 'f %s %s\n' "$hash" "$path" >>"$output"
+      else
+        return 1
+      fi
+    done <"$list"
+  )
+  status=$?
+  rm -f "$list"
+  return "$status"
+}
+
+valid_state() {
+  local state="$1" owner revision lines
+  [ -f "$state" ] && [ ! -L "$state" ] || return 1
+  owner="$(sed -n '1p' "$state")"
+  revision="$(sed -n '2p' "$state")"
+  lines="$(wc -l <"$state" | tr -d ' ')"
+  [ "$owner" = "owner=$OWNER" ] && [[ "$revision" =~ ^revision=[0-9a-f]{40}$ ]] && [ "$lines" = 2 ]
+}
+
+preflight_parent() {
+  local path="$1" parent
+  case "$path" in "$HOME"/*) ;; *) die "destination escapes HOME: $path" ;; esac
+  parent="$(dirname "$path")"
+  while [ "$parent" != "$HOME" ]; do
+    if [ -L "$parent" ]; then
+      collision "$path" "parent $parent is a symlink"
+    elif [ -e "$parent" ] && [ ! -d "$parent" ]; then
+      collision "$path" "parent $parent is not a directory"
+    fi
+    parent="$(dirname "$parent")"
+  done
+}
+
+resolved_link() {
+  local link="$1" target
+  target="$(readlink "$link")" || return 1
+  (cd "$(dirname "$link")" && cd "$target" 2>/dev/null && pwd -P)
+}
+
+preflight_link() {
+  local target="$1" destination="$2" resolved expected
+  preflight_parent "$destination"
+  if [ -L "$destination" ]; then
+    resolved="$(resolved_link "$destination")" || collision "$destination" 'symlink target is missing or not a directory'
+    expected="$(cd "$target" && pwd -P)"
+    [ "$resolved" = "$expected" ] || collision "$destination" "symlink does not resolve to $expected"
+  elif [ -e "$destination" ]; then
+    collision "$destination" 'only an absent path or the expected Sepia symlink is managed'
+  fi
+}
+
+preflight_skill_copy() {
+  local destination="$1" manifest
+  preflight_parent "$destination"
+  if [ ! -e "$destination" ] && [ ! -L "$destination" ]; then
+    return
+  fi
+  [ -d "$destination" ] && [ ! -L "$destination" ] || collision "$destination" 'managed Antigravity skill must be a real directory'
+  valid_state "$destination/$STATE_NAME" || collision "$destination" 'ownership state is missing or invalid'
+  [ -f "$destination/$MANIFEST_NAME" ] && [ ! -L "$destination/$MANIFEST_NAME" ] ||
+    collision "$destination" 'content manifest is missing or invalid'
+  manifest="$(mktemp "${TMPDIR:-/tmp}/sepia-manifest.XXXXXX")"
+  if ! snapshot_dir "$destination" "$manifest" || ! cmp -s "$manifest" "$destination/$MANIFEST_NAME"; then
+    rm -f "$manifest"
+    collision "$destination" 'managed copy was modified'
+  fi
+  rm -f "$manifest"
+}
+
+preflight_workflow() {
+  local workflow="$1" state="$2" expected_hash actual_hash revision lines
+  preflight_parent "$workflow"
+  preflight_parent "$state"
+  if [ ! -e "$workflow" ] && [ ! -L "$workflow" ]; then
+    [ ! -e "$state" ] && [ ! -L "$state" ] || collision "$state" 'orphaned workflow ownership state'
+    return
+  fi
+  [ -f "$workflow" ] && [ ! -L "$workflow" ] || collision "$workflow" 'managed workflow must be a regular file, not a symlink'
+  [ -f "$state" ] && [ ! -L "$state" ] || collision "$workflow" 'workflow ownership state is missing or invalid'
+  [ "$(sed -n '1p' "$state")" = "owner=$OWNER" ] || collision "$workflow" 'workflow owner is invalid'
+  revision="$(sed -n '2p' "$state")"
+  expected_hash="$(sed -n '3p' "$state")"
+  lines="$(wc -l <"$state" | tr -d ' ')"
+  [[ "$revision" =~ ^revision=[0-9a-f]{40}$ ]] && [[ "$expected_hash" =~ ^sha256=[0-9a-f]{64}$ ]] && [ "$lines" = 3 ] ||
+    collision "$workflow" 'workflow ownership state is invalid'
+  actual_hash="$(sha256_file "$workflow")"
+  [ "sha256=$actual_hash" = "$expected_hash" ] || collision "$workflow" 'managed workflow was modified'
+}
+
+validate_clone_location() {
+  local destination
+  for destination in "$CLAUDE" "$CODEX" "$GROK" "$AG" "$WF" "$WF_STATE"; do
+    case "$CLONE_DIR/" in "$destination/"*) die "SEPIA_HOME cannot be inside destination $destination" ;; esac
+    case "$destination/" in "$CLONE_DIR/"*) die "destination $destination cannot be inside SEPIA_HOME" ;; esac
+  done
+}
+
+preflight_all() {
+  local skill="$1"
+  preflight_link "$skill" "$CLAUDE"
+  preflight_link "$skill" "$CODEX"
+  preflight_link "$skill" "$GROK"
+  preflight_skill_copy "$AG"
+  preflight_workflow "$WF" "$WF_STATE"
+}
+
+prepare_checkout() {
+  local destination="$1" temp fetched
+  mkdir -p "$(dirname "$destination")"
+  temp="$(mktemp -d "${destination}.tmp.XXXXXX")"
+  git_safe init -q "$temp"
+  git_safe -C "$temp" remote add origin "$REPO_URL"
+  if ! git_safe -C "$temp" fetch -q --depth 1 origin "$REF"; then
+    rm -rf -- "$temp"
+    die "cannot fetch commit $REF from $REPO_URL"
+  fi
+  fetched="$(git_safe -C "$temp" rev-parse 'FETCH_HEAD^{commit}')"
+  [ "$fetched" = "$REF" ] || { rm -rf -- "$temp"; die "fetched commit $fetched does not match SEPIA_REF $REF"; }
+  if ! verify_running_installer "$temp" "$REF"; then
+    rm -rf -- "$temp"
+    die 'running installer bytes do not match install.sh at SEPIA_REF'
+  fi
+  git_safe -C "$temp" checkout -q --detach "$REF"
+  verify_clean_checkout "$temp" "$REF"
+  printf '%s\n' "$temp"
+}
+
+bootstrap() {
+  local expected_skill="$CLONE_DIR/skills/sepia" temp backup failed current oid
+  if [ -e "$CLONE_DIR" ] || [ -L "$CLONE_DIR" ]; then
+    [ -d "$CLONE_DIR" ] && [ ! -L "$CLONE_DIR" ] || die "$CLONE_DIR exists but is not a real directory"
+    [ -d "$CLONE_DIR/.git" ] && [ ! -L "$CLONE_DIR/.git" ] || die "$CLONE_DIR/.git must be a real directory"
+    verify_origin "$CLONE_DIR"
+    [ -f "$CLONE_DIR/install.sh" ] && [ ! -L "$CLONE_DIR/install.sh" ] || die "$CLONE_DIR/install.sh has an unexpected type"
+    [ -z "$(git_safe -C "$CLONE_DIR" status --porcelain=v1 --untracked-files=all)" ] ||
+      die "$CLONE_DIR is dirty or contains untracked files; refusing to execute or replace its installer"
+    current="$(git_safe -C "$CLONE_DIR" rev-parse 'HEAD^{commit}')"
+    oid="$(verify_installer_entry "$CLONE_DIR" "$current")"
+    [ "$(git_safe -C "$CLONE_DIR" hash-object install.sh)" = "$oid" ] ||
+      die "$CLONE_DIR/install.sh does not match its current HEAD"
+  elif [ "$ACTION" = uninstall ]; then
+    die "$CLONE_DIR does not exist; there is no verified installer to run"
+  fi
+
+  preflight_all "$expected_skill"
+
+  if [ "$ACTION" = uninstall ]; then
+    verify_clean_checkout "$CLONE_DIR" "$REF"
+    verify_running_installer "$CLONE_DIR" "$REF" || die 'running installer bytes do not match install.sh at SEPIA_REF'
+    exec env SEPIA_REF="$REF" SEPIA_REPO="$REPO_URL" SEPIA_HOME="$CLONE_DIR" SEPIA_ACTION=uninstall bash "$CLONE_DIR/install.sh"
+  fi
+
+  temp="$(prepare_checkout "$CLONE_DIR")"
+  if [ -e "$CLONE_DIR" ]; then
+    backup="$CLONE_DIR.sepia-backup.$$"
+    failed="$CLONE_DIR.sepia-failed.$$"
+    [ ! -e "$backup" ] && [ ! -L "$backup" ] && [ ! -e "$failed" ] && [ ! -L "$failed" ] || {
+      rm -rf -- "$temp"
+      die 'temporary checkout path collision'
+    }
+    mv "$CLONE_DIR" "$backup"
+    mv "$temp" "$CLONE_DIR"
+    if env SEPIA_REF="$REF" SEPIA_REPO="$REPO_URL" SEPIA_HOME="$CLONE_DIR" bash "$CLONE_DIR/install.sh"; then
+      rm -rf -- "$backup"
+      exit 0
+    fi
+    mv "$CLONE_DIR" "$failed"
+    mv "$backup" "$CLONE_DIR"
+    rm -rf -- "$failed"
+    die 'installation failed; the previous checkout was restored'
+  fi
+
+  mv "$temp" "$CLONE_DIR"
+  exec env SEPIA_REF="$REF" SEPIA_REPO="$REPO_URL" SEPIA_HOME="$CLONE_DIR" bash "$CLONE_DIR/install.sh"
+}
+
+install_link() {
+  local target="$1" destination="$2"
+  if [ ! -L "$destination" ]; then
+    mkdir -p "$(dirname "$destination")"
+    ln -s "$target" "$destination"
+  fi
+  printf 'linked  %s\n' "$destination"
+}
+
+install_skill_copy() {
+  local source="$1" destination="$2" temp backup
+  mkdir -p "$(dirname "$destination")"
+  temp="$(mktemp -d "${destination}.tmp.XXXXXX")"
+  cp -R "$source"/. "$temp"/
+  snapshot_dir "$temp" "$temp/$MANIFEST_NAME" || { rm -rf -- "$temp"; die 'canonical skill contains an unsupported file type or symlink'; }
+  printf 'owner=%s\nrevision=%s\n' "$OWNER" "$REF" >"$temp/$STATE_NAME"
+  if [ -e "$destination" ]; then
+    backup="$destination.sepia-backup.$$"
+    [ ! -e "$backup" ] && [ ! -L "$backup" ] || { rm -rf -- "$temp"; die "temporary path exists: $backup"; }
+    mv "$destination" "$backup"
+    if mv "$temp" "$destination"; then
+      rm -rf -- "$backup"
+    else
+      mv "$backup" "$destination"
+      rm -rf -- "$temp"
+      die "could not replace $destination; previous copy was restored"
+    fi
+  else
+    mv "$temp" "$destination"
+  fi
+  printf 'copied  %s\n' "$destination"
+}
+
+install_workflow() {
+  local source="$1" workflow="$2" state="$3" temp temp_state hash
+  mkdir -p "$(dirname "$workflow")"
+  temp="$(mktemp "${workflow}.tmp.XXXXXX")"
+  temp_state="$(mktemp "${state}.tmp.XXXXXX")"
+  cp "$source" "$temp"
+  hash="$(sha256_file "$temp")"
+  printf 'owner=%s\nrevision=%s\nsha256=%s\n' "$OWNER" "$REF" "$hash" >"$temp_state"
+  mv -f "$temp" "$workflow"
+  mv -f "$temp_state" "$state"
+  printf 'copied  %s\n' "$workflow"
+}
+
+uninstall_all() {
+  local path
+  preflight_all "$SKILL"
+  verify_clean_checkout "$ROOT" "$REF"
+  for path in "$CLAUDE" "$CODEX" "$GROK"; do
+    if [ -L "$path" ]; then
+      rm "$path"
+      printf 'removed %s\n' "$path"
+    fi
+  done
+  if [ -d "$AG" ]; then
+    rm -rf -- "$AG"
+    printf 'removed %s\n' "$AG"
+  fi
+  if [ -f "$WF" ]; then
+    rm "$WF" "$WF_STATE"
+    printf 'removed %s\n' "$WF"
+  fi
+  printf 'Kept checkout: %s\n' "$ROOT"
+}
+
+validate_inputs
+CLAUDE="$HOME/.claude/skills/sepia"
+CODEX="$HOME/.agents/skills/sepia"
+GROK="$HOME/.grok/skills/sepia"
 AG="$HOME/.gemini/config/skills/sepia"
-mkdir -p "$(dirname "$AG")"
-rm -rf "$AG"
-cp -R "$SKILL" "$AG"
-echo "copied  $AG"
-
-# Antigravity global workflow: adds the /sepia slash command (skills alone have no slash there)
 WF="$HOME/.gemini/antigravity/global_workflows/sepia.md"
-mkdir -p "$(dirname "$WF")"
-cp "$ROOT/.agents/workflows/sepia.md" "$WF"
-echo "copied  $WF"
+WF_STATE="$WF$STATE_NAME"
+validate_clone_location
 
-echo ""
-echo "Installed at user scope:"
-echo "  Claude Code : ~/.claude/skills/sepia (symlink)"
-echo "  Codex       : ~/.agents/skills/sepia (symlink)"
-echo "  Grok Build  : ~/.grok/skills/sepia (symlink)"
-echo "  Antigravity : ~/.gemini/config/skills/sepia (copy) + /sepia workflow"
-echo ""
-echo "Keep this clone: the symlinks point into it. To update everything,"
-echo "re-run the install one-liner (or 'git pull' here, then re-run"
-echo "install.sh to refresh the Antigravity copy)."
+SCRIPT_DIR=""
+SCRIPT_PATH=""
+if [ -n "$SCRIPT_SRC" ] && [ -f "$SCRIPT_SRC" ] && [ ! -L "$SCRIPT_SRC" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SRC")" && pwd -P)"
+  SCRIPT_PATH="$SCRIPT_DIR/$(basename "$SCRIPT_SRC")"
+fi
+if [ -z "$SCRIPT_DIR" ] || [ "$SCRIPT_PATH" != "$SCRIPT_DIR/install.sh" ] || [ ! -f "$SCRIPT_DIR/skills/sepia/SKILL.md" ]; then
+  bootstrap
+fi
+
+ROOT="$(git_safe -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)" || die 'installer is not in a Git checkout'
+[ "$(cd "$ROOT" && pwd -P)" = "$SCRIPT_DIR" ] || die 'install.sh must be run from the checkout root'
+verify_clean_checkout "$ROOT" "$REF"
+SKILL="$ROOT/skills/sepia"
+[ -d "$SKILL" ] && [ ! -L "$SKILL" ] || die 'canonical skills/sepia directory is missing or is a symlink'
+[ -z "$(find "$SKILL" -type l -print -quit)" ] || die 'canonical skills/sepia must not contain symlinks'
+[ -f "$ROOT/.agents/workflows/sepia.md" ] && [ ! -L "$ROOT/.agents/workflows/sepia.md" ] || die 'canonical workflow is missing or is a symlink'
+
+if [ "$ACTION" = uninstall ]; then
+  uninstall_all
+  exit 0
+fi
+
+preflight_all "$SKILL"
+verify_clean_checkout "$ROOT" "$REF"
+install_link "$SKILL" "$CLAUDE"
+install_link "$SKILL" "$CODEX"
+install_link "$SKILL" "$GROK"
+install_skill_copy "$SKILL" "$AG"
+install_workflow "$ROOT/.agents/workflows/sepia.md" "$WF" "$WF_STATE"
+
+printf '\nInstalled revision %s at user scope.\n' "$REF"
+printf 'Keep %s: the Claude, Codex, and Grok links use its canonical skill.\n' "$ROOT"

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ verify_installer_entry() {
 verify_running_installer() {
   local root="$1" revision="$2" oid
   oid="$(verify_installer_entry "$root" "$revision")"
-  [ "$(git_safe -C "$root" hash-object "$SCRIPT_SRC")" = "$oid" ]
+  [ "$(git_safe -C "$root" hash-object --no-filters -- "$SCRIPT_SRC")" = "$oid" ]
 }
 
 verify_origin() {
@@ -91,20 +91,80 @@ verify_origin() {
   [ "$origins" = "$REPO_URL" ] || die "$root has a foreign or ambiguous origin; expected exactly $REPO_URL"
 }
 
+verify_payload() {
+  local root="$1" revision="$2" record metadata mode type oid path relative entry flag actual_oid
+  local expected_count=0 actual_count=0 found_installer=0 found_skill=0 found_workflow=0
+
+  while IFS= read -r -d '' record; do
+    flag="${record%% *}"
+    case "$flag" in
+      [a-z]|S) die "$root payload index contains assume-unchanged or skip-worktree flags" ;;
+    esac
+  done < <(git_safe -C "$root" ls-files -z -v -- install.sh skills/sepia .agents/workflows/sepia.md)
+
+  while IFS= read -r -d '' record; do
+    metadata="${record%%$'\t'*}"
+    path="${record#*$'\t'}"
+    read -r mode type oid <<<"$metadata"
+    [ "$type" = blob ] || die "revision $revision payload contains a non-file entry: $path"
+    case "$path" in
+      install.sh)
+        [ "$mode" = 100755 ] || die "revision $revision does not contain install.sh as an executable regular file"
+        found_installer=1
+        ;;
+      skills/sepia/*)
+        case "$mode" in 100644|100755) ;; *) die "revision $revision payload has an unsupported mode at $path" ;; esac
+        [ "$path" = skills/sepia/SKILL.md ] && found_skill=1
+        ;;
+      .agents/workflows/sepia.md)
+        case "$mode" in 100644|100755) ;; *) die "revision $revision payload has an unsupported mode at $path" ;; esac
+        found_workflow=1
+        ;;
+      *) die "revision $revision payload has an unexpected path: $path" ;;
+    esac
+    expected_count=$((expected_count + 1))
+  done < <(git_safe -C "$root" ls-tree -r -z --full-tree "$revision" -- install.sh skills/sepia .agents/workflows/sepia.md)
+
+  [ "$found_installer" = 1 ] || die "revision $revision is missing install.sh"
+  [ "$found_skill" = 1 ] || die "revision $revision is missing skills/sepia/SKILL.md"
+  [ "$found_workflow" = 1 ] || die "revision $revision is missing .agents/workflows/sepia.md"
+  [ -d "$root/skills/sepia" ] && [ ! -L "$root/skills/sepia" ] || die "$root/skills/sepia must be a real directory"
+  [ -e "$root/install.sh" ] || [ -L "$root/install.sh" ] || die "$root/install.sh is missing"
+  [ -e "$root/.agents/workflows/sepia.md" ] || [ -L "$root/.agents/workflows/sepia.md" ] ||
+    die "$root/.agents/workflows/sepia.md is missing"
+
+  while IFS= read -r -d '' path; do
+    relative="${path#"$root"/}"
+    entry="$(git_safe -C "$root" ls-tree "$revision" -- ":(literal)$relative")"
+    [ -n "$entry" ] || die "$root payload has an unexpected path: $relative"
+    read -r mode type oid _ <<<"$entry"
+    [ "$type" = blob ] && [ -f "$path" ] && [ ! -L "$path" ] ||
+      die "$root payload path has an unexpected type: $relative"
+    case "$mode" in
+      100755) [ -x "$path" ] || die "$root payload path must be executable: $relative" ;;
+      100644) [ ! -x "$path" ] || die "$root payload path must not be executable: $relative" ;;
+      *) die "revision $revision payload has an unsupported mode at $relative" ;;
+    esac
+    actual_oid="$(git_safe -C "$root" hash-object --no-filters -- "$relative")"
+    [ "$actual_oid" = "$oid" ] || die "$root payload does not match revision $revision: $relative"
+    actual_count=$((actual_count + 1))
+  done < <(find "$root/install.sh" "$root/skills/sepia" "$root/.agents/workflows/sepia.md" -mindepth 0 ! -type d -print0)
+
+  [ "$actual_count" = "$expected_count" ] || die "$root payload paths do not match revision $revision"
+}
+
 verify_clean_checkout() {
-  local root="$1" expected="$2" head oid
+  local root="$1" expected="$2" head
   if [ -L "$root/.git" ] || { [ ! -d "$root/.git" ] && [ ! -f "$root/.git" ]; }; then
     die "$root/.git has an unexpected type"
   fi
   git_safe -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$root is not a Git checkout"
   verify_origin "$root"
-  [ -f "$root/install.sh" ] && [ ! -L "$root/install.sh" ] || die "$root/install.sh must be a regular file, not a symlink"
   [ -z "$(git_safe -C "$root" status --porcelain=v1 --untracked-files=all)" ] ||
     die "$root is dirty or contains untracked files; refusing to execute or replace its installer"
   head="$(git_safe -C "$root" rev-parse 'HEAD^{commit}')"
   [ "$head" = "$expected" ] || die "$root HEAD $head does not match SEPIA_REF $expected"
-  oid="$(verify_installer_entry "$root" "$expected")"
-  [ "$(git_safe -C "$root" hash-object install.sh)" = "$oid" ] || die "$root/install.sh does not match revision $expected"
+  verify_payload "$root" "$expected"
 }
 
 snapshot_dir() {
@@ -250,7 +310,7 @@ prepare_checkout() {
 }
 
 bootstrap() {
-  local expected_skill="$CLONE_DIR/skills/sepia" temp backup failed current oid
+  local expected_skill="$CLONE_DIR/skills/sepia" temp backup failed current
   if [ -e "$CLONE_DIR" ] || [ -L "$CLONE_DIR" ]; then
     [ -d "$CLONE_DIR" ] && [ ! -L "$CLONE_DIR" ] || die "$CLONE_DIR exists but is not a real directory"
     [ -d "$CLONE_DIR/.git" ] && [ ! -L "$CLONE_DIR/.git" ] || die "$CLONE_DIR/.git must be a real directory"
@@ -259,9 +319,7 @@ bootstrap() {
     [ -z "$(git_safe -C "$CLONE_DIR" status --porcelain=v1 --untracked-files=all)" ] ||
       die "$CLONE_DIR is dirty or contains untracked files; refusing to execute or replace its installer"
     current="$(git_safe -C "$CLONE_DIR" rev-parse 'HEAD^{commit}')"
-    oid="$(verify_installer_entry "$CLONE_DIR" "$current")"
-    [ "$(git_safe -C "$CLONE_DIR" hash-object install.sh)" = "$oid" ] ||
-      die "$CLONE_DIR/install.sh does not match its current HEAD"
+    verify_payload "$CLONE_DIR" "$current"
   elif [ "$ACTION" = uninstall ]; then
     die "$CLONE_DIR does not exist; there is no verified installer to run"
   fi
@@ -504,9 +562,6 @@ ROOT="$(git_safe -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)" || die
 [ "$(cd "$ROOT" && pwd -P)" = "$SCRIPT_DIR" ] || die 'install.sh must be run from the checkout root'
 verify_clean_checkout "$ROOT" "$REF"
 SKILL="$ROOT/skills/sepia"
-[ -d "$SKILL" ] && [ ! -L "$SKILL" ] || die 'canonical skills/sepia directory is missing or is a symlink'
-[ -z "$(find "$SKILL" -type l -print -quit)" ] || die 'canonical skills/sepia must not contain symlinks'
-[ -f "$ROOT/.agents/workflows/sepia.md" ] && [ ! -L "$ROOT/.agents/workflows/sepia.md" ] || die 'canonical workflow is missing or is a symlink'
 
 if [ "$ACTION" = uninstall ]; then
   uninstall_all

--- a/install.sh
+++ b/install.sh
@@ -294,54 +294,170 @@ bootstrap() {
     die 'installation failed; the previous checkout was restored'
   fi
 
+  failed="$CLONE_DIR.sepia-failed.$$"
+  [ ! -e "$failed" ] && [ ! -L "$failed" ] || {
+    rm -rf -- "$temp"
+    die 'temporary checkout path collision'
+  }
   mv "$temp" "$CLONE_DIR"
-  exec env SEPIA_REF="$REF" SEPIA_REPO="$REPO_URL" SEPIA_HOME="$CLONE_DIR" bash "$CLONE_DIR/install.sh"
+  if env SEPIA_REF="$REF" SEPIA_REPO="$REPO_URL" SEPIA_HOME="$CLONE_DIR" bash "$CLONE_DIR/install.sh"; then
+    exit 0
+  fi
+  mv "$CLONE_DIR" "$failed"
+  rm -rf -- "$failed"
+  die 'installation failed; the new checkout and destinations were removed'
 }
 
-install_link() {
+TX_CREATED_DIRS=()
+TX_CREATED_LINKS=()
+TX_AG_TEMP=""
+TX_WF_TEMP=""
+TX_WF_STATE_TEMP=""
+TX_AG_BACKUP=""
+TX_WF_BACKUP=""
+TX_WF_STATE_BACKUP=""
+TX_AG_BACKED_UP=0
+TX_WF_BACKED_UP=0
+TX_WF_STATE_BACKED_UP=0
+TX_AG_PUBLISHED=0
+TX_WF_PUBLISHED=0
+TX_WF_STATE_PUBLISHED=0
+
+ensure_parent() {
+  local parent current i
+  local -a missing=()
+  parent="$(dirname "$1")"
+  current="$parent"
+  while [ "$current" != "$HOME" ] && [ ! -e "$current" ] && [ ! -L "$current" ]; do
+    missing[${#missing[@]}]="$current"
+    current="$(dirname "$current")"
+  done
+  for ((i=${#missing[@]} - 1; i >= 0; i--)); do
+    TX_CREATED_DIRS[${#TX_CREATED_DIRS[@]}]="${missing[$i]}"
+  done
+  mkdir -p "$parent"
+}
+
+rollback_install() {
+  local failed=0 i path
+  set +e
+  if [ "$TX_WF_STATE_PUBLISHED" = 1 ]; then rm -rf -- "$WF_STATE" || failed=1; fi
+  if [ "$TX_WF_STATE_BACKED_UP" = 1 ]; then mv "$TX_WF_STATE_BACKUP" "$WF_STATE" || failed=1; fi
+  if [ "$TX_WF_PUBLISHED" = 1 ]; then rm -rf -- "$WF" || failed=1; fi
+  if [ "$TX_WF_BACKED_UP" = 1 ]; then mv "$TX_WF_BACKUP" "$WF" || failed=1; fi
+  if [ "$TX_AG_PUBLISHED" = 1 ]; then rm -rf -- "$AG" || failed=1; fi
+  if [ "$TX_AG_BACKED_UP" = 1 ]; then mv "$TX_AG_BACKUP" "$AG" || failed=1; fi
+  for ((i=${#TX_CREATED_LINKS[@]} - 1; i >= 0; i--)); do
+    rm -f -- "${TX_CREATED_LINKS[$i]}" || failed=1
+  done
+  for path in "$TX_AG_TEMP" "$TX_WF_TEMP" "$TX_WF_STATE_TEMP"; do
+    if [ -n "$path" ]; then rm -rf -- "$path" || failed=1; fi
+  done
+  for ((i=${#TX_CREATED_DIRS[@]} - 1; i >= 0; i--)); do
+    if [ -d "${TX_CREATED_DIRS[$i]}" ] && [ ! -L "${TX_CREATED_DIRS[$i]}" ]; then
+      rmdir "${TX_CREATED_DIRS[$i]}" || failed=1
+    fi
+  done
+  if [ "$failed" != 0 ]; then
+    printf 'sepia installer: destination rollback was incomplete; inspect paths reported above\n' >&2
+  else
+    printf 'sepia installer: restored all destinations to their pre-install state\n' >&2
+  fi
+}
+
+rollback_on_exit() {
+  local status=$?
+  trap - EXIT
+  rollback_install
+  exit "$status"
+}
+
+check_transaction_paths() {
+  local path
+  TX_AG_BACKUP="$AG.sepia-backup.$$"
+  TX_WF_BACKUP="$WF.sepia-backup.$$"
+  TX_WF_STATE_BACKUP="$WF_STATE.sepia-backup.$$"
+  for path in "$TX_AG_BACKUP" "$TX_WF_BACKUP" "$TX_WF_STATE_BACKUP"; do
+    [ ! -e "$path" ] && [ ! -L "$path" ] || die "temporary path exists: $path"
+  done
+}
+
+stage_install() {
+  local hash
+  ensure_parent "$CLAUDE"
+  ensure_parent "$CODEX"
+  ensure_parent "$GROK"
+  ensure_parent "$AG"
+  ensure_parent "$WF"
+
+  TX_AG_TEMP="$(mktemp -d "${AG}.tmp.XXXXXX")"
+  cp -R "$SKILL"/. "$TX_AG_TEMP"/
+  snapshot_dir "$TX_AG_TEMP" "$TX_AG_TEMP/$MANIFEST_NAME" || die 'canonical skill contains an unsupported file type or symlink'
+  printf 'owner=%s\nrevision=%s\n' "$OWNER" "$REF" >"$TX_AG_TEMP/$STATE_NAME"
+
+  TX_WF_TEMP="$(mktemp "${WF}.tmp.XXXXXX")"
+  TX_WF_STATE_TEMP="$(mktemp "${WF_STATE}.tmp.XXXXXX")"
+  cp "$ROOT/.agents/workflows/sepia.md" "$TX_WF_TEMP"
+  hash="$(sha256_file "$TX_WF_TEMP")"
+  printf 'owner=%s\nrevision=%s\nsha256=%s\n' "$OWNER" "$REF" "$hash" >"$TX_WF_STATE_TEMP"
+}
+
+publish_link() {
   local target="$1" destination="$2"
   if [ ! -L "$destination" ]; then
-    mkdir -p "$(dirname "$destination")"
     ln -s "$target" "$destination"
+    TX_CREATED_LINKS[${#TX_CREATED_LINKS[@]}]="$destination"
   fi
   printf 'linked  %s\n' "$destination"
 }
 
-install_skill_copy() {
-  local source="$1" destination="$2" temp backup
-  mkdir -p "$(dirname "$destination")"
-  temp="$(mktemp -d "${destination}.tmp.XXXXXX")"
-  cp -R "$source"/. "$temp"/
-  snapshot_dir "$temp" "$temp/$MANIFEST_NAME" || { rm -rf -- "$temp"; die 'canonical skill contains an unsupported file type or symlink'; }
-  printf 'owner=%s\nrevision=%s\n' "$OWNER" "$REF" >"$temp/$STATE_NAME"
-  if [ -e "$destination" ]; then
-    backup="$destination.sepia-backup.$$"
-    [ ! -e "$backup" ] && [ ! -L "$backup" ] || { rm -rf -- "$temp"; die "temporary path exists: $backup"; }
-    mv "$destination" "$backup"
-    if mv "$temp" "$destination"; then
-      rm -rf -- "$backup"
-    else
-      mv "$backup" "$destination"
-      rm -rf -- "$temp"
-      die "could not replace $destination; previous copy was restored"
-    fi
-  else
-    mv "$temp" "$destination"
+publish_skill_copy() {
+  if [ -e "$AG" ]; then
+    mv "$AG" "$TX_AG_BACKUP"
+    TX_AG_BACKED_UP=1
   fi
-  printf 'copied  %s\n' "$destination"
+  mv "$TX_AG_TEMP" "$AG"
+  TX_AG_PUBLISHED=1
+  printf 'copied  %s\n' "$AG"
 }
 
-install_workflow() {
-  local source="$1" workflow="$2" state="$3" temp temp_state hash
-  mkdir -p "$(dirname "$workflow")"
-  temp="$(mktemp "${workflow}.tmp.XXXXXX")"
-  temp_state="$(mktemp "${state}.tmp.XXXXXX")"
-  cp "$source" "$temp"
-  hash="$(sha256_file "$temp")"
-  printf 'owner=%s\nrevision=%s\nsha256=%s\n' "$OWNER" "$REF" "$hash" >"$temp_state"
-  mv -f "$temp" "$workflow"
-  mv -f "$temp_state" "$state"
-  printf 'copied  %s\n' "$workflow"
+publish_workflow() {
+  if [ -e "$WF" ]; then
+    mv "$WF" "$TX_WF_BACKUP"
+    TX_WF_BACKED_UP=1
+    mv "$WF_STATE" "$TX_WF_STATE_BACKUP"
+    TX_WF_STATE_BACKED_UP=1
+  fi
+  mv "$TX_WF_TEMP" "$WF"
+  TX_WF_PUBLISHED=1
+  mv "$TX_WF_STATE_TEMP" "$WF_STATE"
+  TX_WF_STATE_PUBLISHED=1
+  printf 'copied  %s\n' "$WF"
+}
+
+finish_install() {
+  local failed=0 path
+  trap - EXIT
+  for path in "$TX_AG_BACKUP" "$TX_WF_BACKUP" "$TX_WF_STATE_BACKUP"; do
+    if [ -e "$path" ] || [ -L "$path" ]; then rm -rf -- "$path" || failed=1; fi
+  done
+  if [ "$failed" != 0 ]; then
+    printf 'sepia installer: warning: installation succeeded but a private backup could not be removed\n' >&2
+  fi
+}
+
+install_all() {
+  check_transaction_paths
+  trap rollback_on_exit EXIT
+  stage_install
+  publish_link "$SKILL" "$CLAUDE"
+  publish_link "$SKILL" "$CODEX"
+  publish_link "$SKILL" "$GROK"
+  publish_skill_copy
+  publish_workflow
+  printf '\nInstalled revision %s at user scope.\n' "$REF"
+  printf 'Keep %s: the Claude, Codex, and Grok links use its canonical skill.\n' "$ROOT"
+  finish_install
 }
 
 uninstall_all() {
@@ -399,11 +515,4 @@ fi
 
 preflight_all "$SKILL"
 verify_clean_checkout "$ROOT" "$REF"
-install_link "$SKILL" "$CLAUDE"
-install_link "$SKILL" "$CODEX"
-install_link "$SKILL" "$GROK"
-install_skill_copy "$SKILL" "$AG"
-install_workflow "$ROOT/.agents/workflows/sepia.md" "$WF" "$WF_STATE"
-
-printf '\nInstalled revision %s at user scope.\n' "$REF"
-printf 'Keep %s: the Claude, Codex, and Grok links use its canonical skill.\n' "$ROOT"
+install_all

--- a/tests/installer-smoke.sh
+++ b/tests/installer-smoke.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TEST_TMPDIR="${TMPDIR:-/tmp}"
+TMP="$(mktemp -d "${TEST_TMPDIR%/}/sepia-installer-test.XXXXXX")"
+trap 'rm -rf -- "$TMP"' EXIT
+export GIT_ALLOW_PROTOCOL=file
+
+pass=0
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+ok() {
+  pass=$((pass + 1))
+  printf 'ok %02d - %s\n' "$pass" "$1"
+}
+
+make_home() {
+  CASE_HOME="$TMP/homes/$1"
+  CASE_CLONE="$TMP/clones/$1"
+  mkdir -p "$CASE_HOME" "$(dirname "$CASE_CLONE")"
+}
+
+snapshot_tree() {
+  local root="$1" output="$2" list="$TMP/tree-list" path relative hash
+  find "$root" -mindepth 1 -print | LC_ALL=C sort >"$list"
+  : >"$output"
+  while IFS= read -r path; do
+    relative="${path#"$root"/}"
+    if [ -L "$path" ]; then
+      printf 'l %s %s\n' "$(readlink "$path")" "$relative" >>"$output"
+    elif [ -d "$path" ]; then
+      printf 'd %s\n' "$relative" >>"$output"
+    elif [ -f "$path" ]; then
+      hash="$(shasum -a 256 "$path" | awk '{print $1}')"
+      printf 'f %s %s\n' "$hash" "$relative" >>"$output"
+    else
+      fail "unsupported test path type: $path"
+    fi
+  done <"$list"
+}
+
+install_from_bootstrap() {
+  HOME="$1" SEPIA_HOME="$2" SEPIA_REPO="$3" SEPIA_REF="$4" bash "$BOOTSTRAP"
+}
+
+assert_reject_bootstrap() {
+  local name="$1" home="$2" clone="$3" repo="$4" ref="$5" before="$TMP/before-$1" after="$TMP/after-$1"
+  snapshot_tree "$home" "$before"
+  if install_from_bootstrap "$home" "$clone" "$repo" "$ref" >"$TMP/$name.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  snapshot_tree "$home" "$after"
+  cmp -s "$before" "$after" || fail "$name changed a destination"
+  ok "$name rejects before destination writes"
+}
+
+assert_reject_uninstall() {
+  local name="$1" home="$2" clone="$3" repo="$4" ref="$5" before="$TMP/before-$1" after="$TMP/after-$1"
+  snapshot_tree "$home" "$before"
+  if HOME="$home" SEPIA_HOME="$clone" SEPIA_REPO="$repo" SEPIA_REF="$ref" SEPIA_ACTION=uninstall \
+    bash "$BOOTSTRAP" >"$TMP/$name.out" 2>&1; then
+    fail "$name uninstall unexpectedly succeeded"
+  fi
+  snapshot_tree "$home" "$after"
+  cmp -s "$before" "$after" || fail "$name uninstall changed a destination"
+  ok "$name uninstall preserves every destination"
+}
+
+make_clone() {
+  git clone -q "$ORIGIN" "$1"
+  git -C "$1" checkout -q --detach "$2"
+}
+
+SOURCE="$TMP/source"
+mkdir -p "$SOURCE/skills" "$SOURCE/.agents/workflows"
+cp "$ROOT/install.sh" "$SOURCE/install.sh"
+chmod 755 "$SOURCE/install.sh"
+cp -R "$ROOT/skills/sepia" "$SOURCE/skills/sepia"
+cp "$ROOT/.agents/workflows/sepia.md" "$SOURCE/.agents/workflows/sepia.md"
+git -C "$SOURCE" init -q
+git -C "$SOURCE" config user.name 'Sepia Installer Test'
+git -C "$SOURCE" config user.email 'installer-test@example.invalid'
+git -C "$SOURCE" add .
+git -C "$SOURCE" commit -qm 'fixture v1'
+REF1="$(git -C "$SOURCE" rev-parse HEAD)"
+
+ORIGIN="$TMP/origin.git"
+git clone -q --bare "$SOURCE" "$ORIGIN"
+git -C "$SOURCE" remote add origin "$ORIGIN"
+printf '\nfixture revision two\n' >>"$SOURCE/skills/sepia/SKILL.md"
+git -C "$SOURCE" add skills/sepia/SKILL.md
+git -C "$SOURCE" commit -qm 'fixture v2'
+REF2="$(git -C "$SOURCE" rev-parse HEAD)"
+git -C "$SOURCE" push -q origin HEAD
+
+BOOTSTRAP="$TMP/install.sh"
+cp "$ROOT/install.sh" "$BOOTSTRAP"
+chmod 755 "$BOOTSTRAP"
+
+make_home clean
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF1" >/dev/null
+for path in .claude/skills/sepia .agents/skills/sepia .grok/skills/sepia; do
+  [ -L "$CASE_HOME/$path" ] || fail "clean install did not create $path symlink"
+  [ "$(cd "$CASE_HOME/$path" && pwd -P)" = "$(cd "$CASE_CLONE/skills/sepia" && pwd -P)" ] ||
+    fail "$path does not use the canonical skill"
+done
+[ -f "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-state" ] || fail 'Antigravity skill is unmarked'
+[ -f "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-manifest" ] || fail 'Antigravity skill lacks a manifest'
+[ -f "$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md.sepia-install-state" ] || fail 'workflow is unmarked'
+ok 'clean local-file bootstrap install'
+
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+[ "$(git -C "$CASE_CLONE" rev-parse HEAD)" = "$REF2" ] || fail 'managed update did not select REF2'
+grep -q 'fixture revision two' "$CASE_HOME/.gemini/config/skills/sepia/SKILL.md" || fail 'managed copy did not update'
+grep -q "revision=$REF2" "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-state" || fail 'managed state did not update'
+ok 'repeat managed update'
+
+make_home regular_file
+mkdir -p "$CASE_HOME/.claude/skills"
+printf 'sentinel\n' >"$CASE_HOME/.claude/skills/sepia"
+assert_reject_bootstrap regular_file "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home nonempty_dir
+mkdir -p "$CASE_HOME/.agents/skills/sepia"
+printf 'sentinel\n' >"$CASE_HOME/.agents/skills/sepia/keep"
+assert_reject_bootstrap nonempty_dir "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home wrong_symlink
+mkdir -p "$CASE_HOME/.grok/skills" "$CASE_HOME/target"
+printf 'sentinel\n' >"$CASE_HOME/target/keep"
+ln -s "$CASE_HOME/target" "$CASE_HOME/.grok/skills/sepia"
+assert_reject_bootstrap wrong_symlink "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home workflow_symlink
+mkdir -p "$CASE_HOME/.gemini/antigravity/global_workflows"
+printf 'sentinel\n' >"$CASE_HOME/workflow-target"
+ln -s "$CASE_HOME/workflow-target" "$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md"
+assert_reject_bootstrap workflow_symlink "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home legacy_skill
+mkdir -p "$CASE_HOME/.gemini/config/skills"
+cp -R "$SOURCE/skills/sepia" "$CASE_HOME/.gemini/config/skills/sepia"
+assert_reject_bootstrap legacy_unmarked_skill "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home legacy_workflow
+mkdir -p "$CASE_HOME/.gemini/antigravity/global_workflows"
+cp "$SOURCE/.agents/workflows/sepia.md" "$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md"
+assert_reject_bootstrap legacy_unmarked_workflow "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home modified_skill
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+printf 'local edit\n' >>"$CASE_HOME/.gemini/config/skills/sepia/SKILL.md"
+assert_reject_bootstrap modified_managed_skill "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home modified_workflow
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+printf 'local edit\n' >>"$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md"
+assert_reject_bootstrap modified_managed_workflow "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home foreign_origin
+make_clone "$CASE_CLONE" "$REF2"
+git -C "$CASE_CLONE" remote set-url origin "$TMP/foreign.git"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap foreign_origin "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home dirty_checkout
+make_clone "$CASE_CLONE" "$REF2"
+printf 'dirty\n' >>"$CASE_CLONE/skills/sepia/SKILL.md"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap dirty_checkout "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home untracked_checkout
+make_clone "$CASE_CLONE" "$REF2"
+printf 'untracked\n' >"$CASE_CLONE/untracked"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap untracked_checkout "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home symlinked_installer
+make_clone "$CASE_CLONE" "$REF2"
+rm "$CASE_CLONE/install.sh"
+ln -s skills/sepia/SKILL.md "$CASE_CLONE/install.sh"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap symlinked_installer "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home invalid_revision
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap invalid_revision "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" main
+
+make_home nonfull_revision
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap nonfull_revision "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "${REF2%?}"
+
+make_home unsafe_repo_transport
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap unsafe_repo_transport "$CASE_HOME" "$CASE_CLONE" 'ext::sh -c id' "$REF2"
+
+make_home overlapping_home
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap overlapping_home "$CASE_HOME" "$CASE_HOME/.claude/skills/sepia/checkout" "$ORIGIN" "$REF2"
+
+make_home head_mismatch
+make_clone "$CASE_CLONE" "$REF1"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+before="$TMP/before-head-mismatch"
+after="$TMP/after-head-mismatch"
+snapshot_tree "$CASE_HOME" "$before"
+if HOME="$CASE_HOME" SEPIA_HOME="$CASE_CLONE" SEPIA_REPO="$ORIGIN" SEPIA_REF="$REF2" \
+  bash "$CASE_CLONE/install.sh" >"$TMP/head_mismatch.out" 2>&1; then
+  fail 'HEAD mismatch unexpectedly succeeded'
+fi
+snapshot_tree "$CASE_HOME" "$after"
+cmp -s "$before" "$after" || fail 'HEAD mismatch changed a destination'
+ok 'HEAD/revision mismatch rejects before destination writes'
+
+BAD_SOURCE="$TMP/bad-source"
+mkdir -p "$BAD_SOURCE/skills/sepia" "$BAD_SOURCE/.agents/workflows"
+cp "$ROOT/skills/sepia/SKILL.md" "$BAD_SOURCE/skills/sepia/SKILL.md"
+cp "$ROOT/.agents/workflows/sepia.md" "$BAD_SOURCE/.agents/workflows/sepia.md"
+ln -s skills/sepia/SKILL.md "$BAD_SOURCE/install.sh"
+git -C "$BAD_SOURCE" init -q
+git -C "$BAD_SOURCE" config user.name 'Sepia Installer Test'
+git -C "$BAD_SOURCE" config user.email 'installer-test@example.invalid'
+git -C "$BAD_SOURCE" add .
+git -C "$BAD_SOURCE" commit -qm 'bad installer type'
+BAD_REF="$(git -C "$BAD_SOURCE" rev-parse HEAD)"
+BAD_ORIGIN="$TMP/bad-origin.git"
+git clone -q --bare "$BAD_SOURCE" "$BAD_ORIGIN"
+make_home bad_installer_type
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_reject_bootstrap unexpected_installer_type "$CASE_HOME" "$CASE_CLONE" "$BAD_ORIGIN" "$BAD_REF"
+
+make_home downloaded_mismatch
+printf 'sentinel\n' >"$CASE_HOME/keep"
+MISMATCH_BOOTSTRAP="$TMP/mismatched-install.sh"
+cp "$BOOTSTRAP" "$MISMATCH_BOOTSTRAP"
+printf '\n# changed after publication\n' >>"$MISMATCH_BOOTSTRAP"
+before="$TMP/before-downloaded-mismatch"
+after="$TMP/after-downloaded-mismatch"
+snapshot_tree "$CASE_HOME" "$before"
+if HOME="$CASE_HOME" SEPIA_HOME="$CASE_CLONE" SEPIA_REPO="$ORIGIN" SEPIA_REF="$REF2" \
+  bash "$MISMATCH_BOOTSTRAP" >"$TMP/downloaded_mismatch.out" 2>&1; then
+  fail 'downloaded installer mismatch unexpectedly succeeded'
+fi
+snapshot_tree "$CASE_HOME" "$after"
+cmp -s "$before" "$after" || fail 'downloaded installer mismatch changed a destination'
+ok 'downloaded installer bytes must match the selected revision'
+
+make_home clean_uninstall
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+target_hash="$(git -C "$CASE_CLONE" hash-object skills/sepia/SKILL.md)"
+HOME="$CASE_HOME" SEPIA_HOME="$CASE_CLONE" SEPIA_REPO="$ORIGIN" SEPIA_REF="$REF2" SEPIA_ACTION=uninstall \
+  bash "$BOOTSTRAP" >/dev/null
+for path in .claude/skills/sepia .agents/skills/sepia .grok/skills/sepia .gemini/config/skills/sepia \
+  .gemini/antigravity/global_workflows/sepia.md .gemini/antigravity/global_workflows/sepia.md.sepia-install-state; do
+  [ ! -e "$CASE_HOME/$path" ] && [ ! -L "$CASE_HOME/$path" ] || fail "clean uninstall left $path"
+done
+[ "$(git -C "$CASE_CLONE" hash-object skills/sepia/SKILL.md)" = "$target_hash" ] || fail 'uninstall changed the symlink target checkout'
+ok 'safe uninstall removes only clean managed artifacts'
+
+make_home uninstall_modified
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+printf 'local edit\n' >>"$CASE_HOME/.gemini/config/skills/sepia/SKILL.md"
+assert_reject_uninstall uninstall_modified "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home uninstall_replacement
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+rm "$CASE_HOME/.claude/skills/sepia"
+printf 'replacement\n' >"$CASE_HOME/.claude/skills/sepia"
+assert_reject_uninstall uninstall_unmanaged_replacement "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home uninstall_wrong_link
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+rm "$CASE_HOME/.grok/skills/sepia"
+mkdir -p "$CASE_HOME/wrong-target"
+printf 'target sentinel\n' >"$CASE_HOME/wrong-target/keep"
+ln -s "$CASE_HOME/wrong-target" "$CASE_HOME/.grok/skills/sepia"
+assert_reject_uninstall uninstall_wrong_final_symlink "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home uninstall_legacy
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
+rm "$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md.sepia-install-state"
+assert_reject_uninstall uninstall_legacy_unmarked "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+printf 'PASS: %d installer safety checks\n' "$pass"

--- a/tests/installer-smoke.sh
+++ b/tests/installer-smoke.sh
@@ -87,6 +87,11 @@ make_clone() {
   git -C "$1" checkout -q --detach "$2"
 }
 
+assert_empty_porcelain() {
+  [ -z "$(git -C "$1" status --porcelain=v1 --untracked-files=all)" ] ||
+    fail "$2 did not reproduce an empty porcelain status"
+}
+
 SOURCE="$TMP/source"
 mkdir -p "$SOURCE/skills" "$SOURCE/.agents/workflows"
 cp "$ROOT/install.sh" "$SOURCE/install.sh"
@@ -140,7 +145,7 @@ done
 [ -f "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-state" ] || fail 'Antigravity skill is unmarked'
 [ -f "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-manifest" ] || fail 'Antigravity skill lacks a manifest'
 [ -f "$CASE_HOME/.gemini/antigravity/global_workflows/sepia.md.sepia-install-state" ] || fail 'workflow is unmarked'
-ok 'clean local-file bootstrap install'
+ok 'clean verified payload installs'
 
 install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
 [ "$(git -C "$CASE_CLONE" rev-parse HEAD)" = "$REF2" ] || fail 'managed update did not select REF2'
@@ -240,6 +245,34 @@ make_clone "$CASE_CLONE" "$REF2"
 printf 'untracked\n' >"$CASE_CLONE/untracked"
 printf 'sentinel\n' >"$CASE_HOME/keep"
 assert_reject_bootstrap untracked_checkout "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+
+make_home assume_unchanged_payload
+make_clone "$CASE_CLONE" "$REF2"
+git -C "$CASE_CLONE" update-index --assume-unchanged skills/sepia/SKILL.md
+printf 'hidden payload edit\n' >>"$CASE_CLONE/skills/sepia/SKILL.md"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_empty_porcelain "$CASE_CLONE" assume_unchanged_payload
+assert_reject_bootstrap assume_unchanged_payload "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+grep -q 'payload index' "$TMP/assume_unchanged_payload.out" || fail 'assume-unchanged payload rejection used the wrong gate'
+
+make_home skip_worktree_payload
+make_clone "$CASE_CLONE" "$REF2"
+git -C "$CASE_CLONE" update-index --skip-worktree skills/sepia/SKILL.md
+printf 'hidden payload edit\n' >>"$CASE_CLONE/skills/sepia/SKILL.md"
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_empty_porcelain "$CASE_CLONE" skip_worktree_payload
+assert_reject_bootstrap skip_worktree_payload "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+grep -q 'payload index' "$TMP/skip_worktree_payload.out" || fail 'skip-worktree payload rejection used the wrong gate'
+
+make_home ignored_payload_addition
+make_clone "$CASE_CLONE" "$REF2"
+printf '/skills/sepia/ignored-added\n' >>"$CASE_CLONE/.git/info/exclude"
+printf 'ignored payload\n' >"$CASE_CLONE/skills/sepia/ignored-added"
+git -C "$CASE_CLONE" check-ignore -q skills/sepia/ignored-added || fail 'ignored payload fixture is not ignored'
+printf 'sentinel\n' >"$CASE_HOME/keep"
+assert_empty_porcelain "$CASE_CLONE" ignored_payload_addition
+assert_reject_bootstrap ignored_payload_addition "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2"
+grep -q 'unexpected path' "$TMP/ignored_payload_addition.out" || fail 'ignored payload rejection used the wrong gate'
 
 make_home symlinked_installer
 make_clone "$CASE_CLONE" "$REF2"

--- a/tests/installer-smoke.sh
+++ b/tests/installer-smoke.sh
@@ -47,6 +47,18 @@ install_from_bootstrap() {
   HOME="$1" SEPIA_HOME="$2" SEPIA_REPO="$3" SEPIA_REF="$4" bash "$BOOTSTRAP"
 }
 
+install_with_late_mv_failure() {
+  local name="$1" home="$2" clone="$3" repo="$4" ref="$5"
+  HOME="$home" SEPIA_HOME="$clone" SEPIA_REPO="$repo" SEPIA_REF="$ref" \
+    PATH="$MV_SHIM_DIR:$PATH" \
+    INSTALLER_TEST_REAL_MV="$REAL_MV" \
+    INSTALLER_TEST_FAIL_DEST="$home/.gemini/antigravity/global_workflows/sepia.md.sepia-install-state" \
+    INSTALLER_TEST_PUBLISHED_SKILL="$home/.gemini/config/skills/sepia/SKILL.md" \
+    INSTALLER_TEST_PUBLISHED_WORKFLOW="$home/.gemini/antigravity/global_workflows/sepia.md" \
+    INSTALLER_TEST_MARKER="$TMP/$name.marker" \
+    bash "$BOOTSTRAP"
+}
+
 assert_reject_bootstrap() {
   local name="$1" home="$2" clone="$3" repo="$4" ref="$5" before="$TMP/before-$1" after="$TMP/after-$1"
   snapshot_tree "$home" "$before"
@@ -92,7 +104,8 @@ ORIGIN="$TMP/origin.git"
 git clone -q --bare "$SOURCE" "$ORIGIN"
 git -C "$SOURCE" remote add origin "$ORIGIN"
 printf '\nfixture revision two\n' >>"$SOURCE/skills/sepia/SKILL.md"
-git -C "$SOURCE" add skills/sepia/SKILL.md
+printf '\nfixture workflow revision two\n' >>"$SOURCE/.agents/workflows/sepia.md"
+git -C "$SOURCE" add skills/sepia/SKILL.md .agents/workflows/sepia.md
 git -C "$SOURCE" commit -qm 'fixture v2'
 REF2="$(git -C "$SOURCE" rev-parse HEAD)"
 git -C "$SOURCE" push -q origin HEAD
@@ -100,6 +113,22 @@ git -C "$SOURCE" push -q origin HEAD
 BOOTSTRAP="$TMP/install.sh"
 cp "$ROOT/install.sh" "$BOOTSTRAP"
 chmod 755 "$BOOTSTRAP"
+
+MV_SHIM_DIR="$TMP/mv-shim"
+REAL_MV="$(command -v mv)"
+mkdir -p "$MV_SHIM_DIR"
+cat >"$MV_SHIM_DIR/mv" <<'SHIM'
+#!/bin/bash
+set -eu
+if [ "$#" -eq 2 ] && [ "$2" = "${INSTALLER_TEST_FAIL_DEST:-}" ] && [ ! -e "${INSTALLER_TEST_MARKER:-}" ]; then
+  grep -q 'fixture revision two' "${INSTALLER_TEST_PUBLISHED_SKILL:?}"
+  grep -q 'fixture workflow revision two' "${INSTALLER_TEST_PUBLISHED_WORKFLOW:?}"
+  : >"${INSTALLER_TEST_MARKER:?}"
+  exit 75
+fi
+exec "${INSTALLER_TEST_REAL_MV:?}" "$@"
+SHIM
+chmod 755 "$MV_SHIM_DIR/mv"
 
 make_home clean
 install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF1" >/dev/null
@@ -118,6 +147,39 @@ install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >/dev/null
 grep -q 'fixture revision two' "$CASE_HOME/.gemini/config/skills/sepia/SKILL.md" || fail 'managed copy did not update'
 grep -q "revision=$REF2" "$CASE_HOME/.gemini/config/skills/sepia/.sepia-install-state" || fail 'managed state did not update'
 ok 'repeat managed update'
+
+make_home late_update_rollback
+install_from_bootstrap "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF1" >/dev/null
+printf 'sentinel\n' >"$CASE_HOME/keep"
+before_home="$TMP/before-late-update-home"
+after_home="$TMP/after-late-update-home"
+before_clone="$TMP/before-late-update-clone"
+after_clone="$TMP/after-late-update-clone"
+snapshot_tree "$CASE_HOME" "$before_home"
+snapshot_tree "$CASE_CLONE" "$before_clone"
+if install_with_late_mv_failure late_update "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >"$TMP/late_update.out" 2>&1; then
+  fail 'late managed-update failure unexpectedly succeeded'
+fi
+[ -f "$TMP/late_update.marker" ] || fail 'late managed-update failure did not reach workflow-state publication'
+snapshot_tree "$CASE_HOME" "$after_home"
+snapshot_tree "$CASE_CLONE" "$after_clone"
+cmp -s "$before_home" "$after_home" || fail 'late managed-update failure did not restore every destination and sentinel'
+cmp -s "$before_clone" "$after_clone" || fail 'late managed-update failure did not restore the checkout byte-for-byte'
+ok 'late managed-update failure restores checkout, links, copies, state, and sentinels'
+
+make_home late_clean_rollback
+printf 'sentinel\n' >"$CASE_HOME/keep"
+before_home="$TMP/before-late-clean-home"
+after_home="$TMP/after-late-clean-home"
+snapshot_tree "$CASE_HOME" "$before_home"
+if install_with_late_mv_failure late_clean "$CASE_HOME" "$CASE_CLONE" "$ORIGIN" "$REF2" >"$TMP/late_clean.out" 2>&1; then
+  fail 'late clean-install failure unexpectedly succeeded'
+fi
+[ -f "$TMP/late_clean.marker" ] || fail 'late clean-install failure did not reach workflow-state publication'
+[ ! -e "$CASE_CLONE" ] && [ ! -L "$CASE_CLONE" ] || fail 'late clean-install failure left the new checkout'
+snapshot_tree "$CASE_HOME" "$after_home"
+cmp -s "$before_home" "$after_home" || fail 'late clean-install failure left a partial destination or changed a sentinel'
+ok 'late clean-install failure removes checkout and every partial destination'
 
 make_home regular_file
 mkdir -p "$CASE_HOME/.claude/skills"


### PR DESCRIPTION
## What changed

The user-scope installer now verifies one full commit SHA across the downloaded bootstrap, fetched commit, checkout HEAD, and tracked executable `install.sh` blob. Existing checkouts must have the exact configured origin and a clean worktree before replacement or execution.

Every Claude, Codex, Grok, and Antigravity destination is preflighted before the first destination write. Canonical symlinks must resolve to the selected checkout; Antigravity copies and workflows carry ownership and content manifests so legacy, modified, wrong-type, and symlink collisions fail closed. Guarded uninstall removes only verified managed artifacts.

`tests/installer-smoke.sh` covers 26 clean install, managed update, collision, source-binding, and uninstall paths without network access or the real HOME.

## Why

The previous installer could delete an unmanaged Antigravity skill directory, overwrite a workflow symlink target, silently nest links below existing directories, reuse an arbitrary Git origin, and execute mutable `main` content.

## Verification

- `/bin/bash tests/installer-smoke.sh` — 26/26 passed
- `bash -n install.sh` and `/bin/bash -n install.sh`
- `shellcheck install.sh tests/installer-smoke.sh`
- Claude plugin validation with `--strict`
- Grok plugin validation
- JSON manifest validation and `git diff --check`
- Fresh outcome verification: `CONFIRMED`, no findings

## Stack

PR 1 of 2, based on `main`. Documentation follows in #5. Until #5 lands, the old mutable-main README command fails safely because the installer requires `SEPIA_REF`; merge #5 immediately after this PR.

No release coordinates are published here, and this PR does not tag or release anything.