### PR TITLE
Add a repository-owned GitHub Star trend chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The general `/sepia` (Claude Code and Grok Build) or `$sepia` (Codex) router rem
 
 Antigravity's pinned `v0.2.0` manual installer remains unchanged and continues to use `/sepia <operation>`. This slice does not add separate Antigravity operation entries.
 
+## Star history
+
+[![GitHub Star history for Nanako0129/sepia](assets/star-history.svg)](https://github.com/Nanako0129/sepia/stargazers)
+
+Committed snapshot from GitHub stargazer timestamps at `2026-08-29 23:02 UTC`: 637 cumulative Stars. This is not live tracking or an automatic refresh.
+
 ## Why another humanizer
 
 Every popular humanizer edits word choice and syntax. [StoryScope](https://arxiv.org/abs/2604.03136) (Russell et al., 2026: 61,608 stories, human + 5 frontier LLMs) showed that a classifier using **narrative-structure features alone** detects AI fiction at 93.2% macro-F1, and that editing the surface style away barely moves it (95.5% → 93.9%). The tells that survive are architectural: themes explained by the narrator, single-track causally-tidy plots, emotions rendered only as bodily sensation, no real-world references, no reader, linear time, endings resolved by protagonist growth and acceptance.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -21,6 +21,12 @@
 
 Antigravity 固定使用 `v0.2.0` 的手動安裝流程，本次維持不變，呼叫方式仍是 `/sepia <operation>`。這個 slice 不為 Antigravity 新增獨立操作入口。
 
+## Star 趨勢
+
+[![Nanako0129/sepia 的 GitHub Star 趨勢圖](assets/star-history.svg)](https://github.com/Nanako0129/sepia/stargazers)
+
+這是依 GitHub stargazer 時間戳記建立、commit 進 repo 的快照；截至 `2026-08-29 23:02 UTC` 共累計 637 顆 Star。圖表不是即時追蹤，也不會自動更新。
+
 ## 為什麼還需要另一個 humanizer
 
 常見的 humanizer 都在改用詞與句法。[StoryScope](https://arxiv.org/abs/2604.03136)（Russell et al., 2026：61,608 篇故事，涵蓋人類與 5 個頂尖 LLM）顯示，只靠**敘事結構特徵**的分類器就能以 93.2% macro-F1 偵測 AI 小說；把字句風格修掉，分類表現也只從 95.5% 降到 93.9%。留下的破綻都在架構層：敘事者直接講明主題、單線且因果收得過於工整的情節、情緒只靠身體感受呈現、沒有真實世界的參照、讀者缺席、時間全程線性，以及靠主角成長與接納收束的結局。

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="360" viewBox="0 0 960 360" role="img" aria-labelledby="title desc">
+  <title id="title">Nanako0129/sepia GitHub Star history</title>
+  <desc id="desc">Cumulative GitHub Stars from 2026-08-28T06:28:52Z through the UTC snapshot 2026-08-29T23:02:25Z. Total: 637.</desc>
+  <!-- Source: GitHub REST API /repos/Nanako0129/sepia/stargazers, application/vnd.github.star+json. Aggregation: hourly cumulative counts. No user identities retained. -->
+  <style>
+    .title { fill: #8a5738; font: 600 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .subtitle, .label { fill: #6e7681; font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .grid { stroke: #8c959f; stroke-opacity: .35; stroke-width: 1; }
+    .axis { stroke: #6e7681; stroke-width: 1.25; }
+    .area { fill: #c69069; fill-opacity: .18; }
+    .trend { fill: none; stroke: #b66a3c; stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
+    .point { fill: #b66a3c; }
+  </style>
+  <text class="title" x="72" y="28">Nanako0129/sepia GitHub Stars</text>
+  <text class="subtitle" x="600" y="28">637 Stars · snapshot 2026-08-29 23:02 UTC</text>
+  <line class="grid" x1="72.0" y1="302.0" x2="932.0" y2="302.0"/><text class="label" x="60.0" y="306.0" text-anchor="end">0</text>
+  <line class="grid" x1="72.0" y1="266.57" x2="932.0" y2="266.57"/><text class="label" x="60.0" y="270.57" text-anchor="end">100</text>
+  <line class="grid" x1="72.0" y1="231.14" x2="932.0" y2="231.14"/><text class="label" x="60.0" y="235.14" text-anchor="end">200</text>
+  <line class="grid" x1="72.0" y1="195.71" x2="932.0" y2="195.71"/><text class="label" x="60.0" y="199.71" text-anchor="end">300</text>
+  <line class="grid" x1="72.0" y1="160.29" x2="932.0" y2="160.29"/><text class="label" x="60.0" y="164.29" text-anchor="end">400</text>
+  <line class="grid" x1="72.0" y1="124.86" x2="932.0" y2="124.86"/><text class="label" x="60.0" y="128.86" text-anchor="end">500</text>
+  <line class="grid" x1="72.0" y1="89.43" x2="932.0" y2="89.43"/><text class="label" x="60.0" y="93.43" text-anchor="end">600</text>
+  <line class="grid" x1="72.0" y1="54.0" x2="932.0" y2="54.0"/><text class="label" x="60.0" y="58.0" text-anchor="end">700</text>
+  <line class="grid" x1="72.0" y1="54.0" x2="72.0" y2="302.0"/><text class="label" x="72.0" y="329.0" text-anchor="start">Aug 28 06:00</text>
+  <line class="grid" x1="287.0" y1="54.0" x2="287.0" y2="302.0"/><text class="label" x="287.0" y="329.0" text-anchor="middle">Aug 28 16:15</text>
+  <line class="grid" x1="502.0" y1="54.0" x2="502.0" y2="302.0"/><text class="label" x="502.0" y="329.0" text-anchor="middle">Aug 29 02:31</text>
+  <line class="grid" x1="717.0" y1="54.0" x2="717.0" y2="302.0"/><text class="label" x="717.0" y="329.0" text-anchor="middle">Aug 29 12:46</text>
+  <line class="grid" x1="932.0" y1="54.0" x2="932.0" y2="302.0"/><text class="label" x="830.0" y="329.0">Aug 29 23:02</text>
+  <line class="axis" x1="72.0" y1="54.0" x2="72.0" y2="302.0"/>
+  <line class="axis" x1="72.0" y1="302.0" x2="932.0" y2="302.0"/>
+  <path class="area" d="M 72.0,302.0 L 72.0,302.0 L 92.95,301.65 L 113.91,297.75 L 134.86,295.27 L 155.82,293.5 L 176.77,290.66 L 197.73,287.83 L 218.68,283.93 L 239.64,281.45 L 260.59,271.18 L 281.55,265.86 L 302.5,258.78 L 323.46,252.75 L 344.41,245.67 L 365.37,237.17 L 386.32,227.6 L 407.28,217.33 L 428.23,206.7 L 449.19,188.27 L 470.14,176.23 L 491.1,164.89 L 512.05,152.85 L 533.01,145.76 L 553.96,138.32 L 574.92,131.94 L 595.87,125.21 L 616.83,117.42 L 637.78,111.39 L 658.74,110.33 L 679.69,108.56 L 700.65,106.79 L 721.6,103.95 L 742.56,101.83 L 763.51,98.64 L 784.47,97.22 L 805.42,95.1 L 826.38,92.62 L 847.33,91.55 L 868.29,91.55 L 889.24,91.55 L 910.2,84.47 L 931.15,76.32 L 932.0,76.32 L 932.0,302.0 Z"/>
+  <polyline class="trend" points="72.0,302.0 92.95,301.65 113.91,297.75 134.86,295.27 155.82,293.5 176.77,290.66 197.73,287.83 218.68,283.93 239.64,281.45 260.59,271.18 281.55,265.86 302.5,258.78 323.46,252.75 344.41,245.67 365.37,237.17 386.32,227.6 407.28,217.33 428.23,206.7 449.19,188.27 470.14,176.23 491.1,164.89 512.05,152.85 533.01,145.76 553.96,138.32 574.92,131.94 595.87,125.21 616.83,117.42 637.78,111.39 658.74,110.33 679.69,108.56 700.65,106.79 721.6,103.95 742.56,101.83 763.51,98.64 784.47,97.22 805.42,95.1 826.38,92.62 847.33,91.55 868.29,91.55 889.24,91.55 910.2,84.47 931.15,76.32 932.0,76.32" vector-effect="non-scaling-stroke"/>
+  <circle class="point" cx="932.0" cy="76.32" r="4"/>
+  <text class="label" x="18" y="178.0" text-anchor="middle" transform="rotate(-90 18 178.0)">Cumulative Stars</text>
+  <text class="label" x="502.0" y="348" text-anchor="middle">UTC</text>
+</svg>

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -4,12 +4,21 @@
   <!-- Source: GitHub REST API /repos/Nanako0129/sepia/stargazers, application/vnd.github.star+json. Aggregation: hourly cumulative counts. No user identities retained. -->
   <style>
     .title { fill: #8a5738; font: 600 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    .subtitle, .label { fill: #6e7681; font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    .grid { stroke: #8c959f; stroke-opacity: .35; stroke-width: 1; }
-    .axis { stroke: #6e7681; stroke-width: 1.25; }
+    .subtitle, .label { fill: #57606a; font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .grid { stroke: #d0d7de; stroke-width: 1; }
+    .axis { stroke: #8c959f; stroke-width: 1.25; }
     .area { fill: #c69069; fill-opacity: .18; }
     .trend { fill: none; stroke: #b66a3c; stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; }
     .point { fill: #b66a3c; }
+    @media (prefers-color-scheme: dark) {
+      .title { fill: #d4a27f; }
+      .subtitle, .label { fill: #8c959f; }
+      .grid { stroke: #30363d; }
+      .axis { stroke: #6e7681; }
+      .area { fill: #c69069; fill-opacity: .2; }
+      .trend { stroke: #d4a27f; }
+      .point { fill: #d4a27f; }
+    }
   </style>
   <text class="title" x="72" y="28">Nanako0129/sepia GitHub Stars</text>
   <text class="subtitle" x="600" y="28">637 Stars · snapshot 2026-08-29 23:02 UTC</text>


### PR DESCRIPTION
## What changed

Add a committed SVG showing Nanako0129/sepia cumulative GitHub Stars from the first recorded Star through the UTC snapshot at 2026-08-29T23:02:25Z. The snapshot contains 637 Stars aggregated into 43 hourly cumulative points.

Both READMEs embed the same relative asset and link to the repository stargazers page. The chart includes accessible title and description text, source accounting, UTC labels, and a neutral transparent presentation.

## Why

The hosted Star History endpoint currently returns a GitHub-access-restriction placeholder for this repository. A repository-owned snapshot keeps the README useful without a broken third-party runtime image.

## Deliberate boundary

This is a committed snapshot, not live tracking. There is no workflow, schedule, write token, generator script, dependency, username dataset, remote asset, or automatic refresh.

## Verification

- GitHub star-media API: 637 timestamps through the recorded snapshot
- First and last included timestamps independently reproduced
- 43 cumulative points reconstructed; SVG coordinate deviation below 0.01 px
- XML and accessibility metadata validation
- No scripts, links, imports, remote fonts, images, or user identities in the SVG
- Transparent, white, and dark visual renders inspected
- English and Traditional Chinese facts and image paths match
- Markdown links, bilingual Bash parity, plugin validators, JSON manifests, and git diff checks
- Fresh outcome verifier: CONFIRMED, no findings

## Stack

Layer 3, based on operation-entry PR #10, which is based on #7. Hold all three PRs unmerged until the stack is frozen and explicitly authorized for merge. No release is part of this PR.