### PR TITLE
feat: add Antigravity plugin packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The general `/sepia` (Claude Code, Grok Build, and Antigravity) or `$sepia` (Cod
 
 ## Install
 
-All four tools use their native plugin installers. Antigravity installs the plugin directly from its GitHub URL through `agy`. Every install defaults to **user scope** — install once, use it in every project.
+All four tools use their native plugin installers. Every install defaults to **user scope** — install once, use it in every project.
 
 ### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -34,22 +34,20 @@ The governing principle throughout: **calibrate to the human distribution, don't
 
 ## Operation entries
 
-The complete plugin package gives Claude Code, Codex, and Grok Build a general router plus four direct operation entries:
+The complete plugin package gives Claude Code, Codex, Grok Build, and Antigravity a general router plus four direct operation entries:
 
-| Operation | Claude Code | Codex | Grok Build | Meaning |
-|---|---|---|---|---|
-| write | `/sepia-write` | `$sepia-write` | `/sepia-write` | Create new prose |
-| review | `/sepia-review` | `$sepia-review` | `/sepia-review` | Diagnose without editing |
-| refactor | `/sepia-refactor` | `$sepia-refactor` | `/sepia-refactor` | Make minimal in-place edits |
-| recreate | `/sepia-recreate` | `$sepia-recreate` | `/sepia-recreate` | Rewrite from the source facts and intent |
+| Operation | Claude Code | Codex | Grok Build | Antigravity | Meaning |
+|---|---|---|---|---|---|
+| write | `/sepia-write` | `$sepia-write` | `/sepia-write` | `/sepia-write` | Create new prose |
+| review | `/sepia-review` | `$sepia-review` | `/sepia-review` | `/sepia-review` | Diagnose without editing |
+| refactor | `/sepia-refactor` | `$sepia-refactor` | `/sepia-refactor` | `/sepia-refactor` | Make minimal in-place edits |
+| recreate | `/sepia-recreate` | `$sepia-recreate` | `/sepia-recreate` | `/sepia-recreate` | Rewrite from the source facts and intent |
 
-The general `/sepia` (Claude Code and Grok Build) or `$sepia` (Codex) router remains available. The operation wrappers depend on their sibling canonical skill, so standalone wrapper installation is unsupported; install the complete plugin package. This table documents package syntax; installed UI and runtime behavior were not exercised for `v0.3.0`.
-
-Antigravity's `v0.3.0` manual installer continues to use `/sepia <operation>`; it does not expose separate operation entries.
+The general `/sepia` (Claude Code, Grok Build, and Antigravity) or `$sepia` (Codex) router remains available. The operation wrappers depend on their sibling canonical skill, so standalone wrapper installation is unsupported; install the complete plugin package. This table documents package syntax; installed UI and runtime behavior were not exercised as part of this change.
 
 ## Install
 
-Claude Code, Codex, and Grok Build use their native plugin installers. Antigravity uses the manual path below. Every install defaults to **user scope** — install once, use it in every project.
+All four tools use their native plugin installers. Antigravity installs the plugin directly from its GitHub URL through `agy`. Every install defaults to **user scope** — install once, use it in every project.
 
 ### Claude Code
 
@@ -91,28 +89,10 @@ Grok also auto-discovers a Claude Code install of sepia if you have one; either 
 
 ### Antigravity
 
-Antigravity has no marketplace. This fresh install is pinned to the current release, `v0.3.0`, and aborts if either destination already exists:
-
 ```bash
-(
-  set -e
-
-  skill="$HOME/.gemini/config/skills/sepia"
-  workflow="$HOME/.gemini/antigravity/global_workflows/sepia.md"
-
-  if [ -e "$skill" ] || [ -L "$skill" ] || [ -e "$workflow" ] || [ -L "$workflow" ]; then
-    echo "Antigravity install aborted: move the existing skill and workflow aside first." >&2
-    exit 1
-  fi
-
-  git clone --branch v0.3.0 --depth 1 https://github.com/Nanako0129/sepia.git "$HOME/.sepia"
-  mkdir -p "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/global_workflows"
-  cp -R "$HOME/.sepia/skills/sepia" "$skill"
-  cp "$HOME/.sepia/.agents/workflows/sepia.md" "$workflow"
-)
+# install directly from GitHub
+agy plugin install https://github.com/Nanako0129/sepia
 ```
-
-Antigravity has no automated updater. To update or roll back, inspect the release you want, move the current clone, skill, and workflow aside under backup names you choose, then repeat this fresh install with that release tag.
 
 ### Skills CLI (alternative, 77+ agents)
 
@@ -127,7 +107,7 @@ When one repo should pin its own copy, commit `skills/sepia/` into that repo as 
 
 ## Uninstall
 
-Claude Code, Codex, and Grok Build each use their native command:
+Each tool uses its native command:
 
 ```bash
 # Claude Code
@@ -138,41 +118,16 @@ codex plugin remove sepia@sepia
 
 # Grok Build
 grok plugin uninstall sepia
+
+# Antigravity
+agy plugin uninstall sepia
 ```
-
-For Antigravity, disable both entries by renaming them. The preflight stops before either move if a source is missing or a `.disabled` target already exists:
-
-```bash
-(
-  set -e
-
-  skill="$HOME/.gemini/config/skills/sepia"
-  workflow="$HOME/.gemini/antigravity/global_workflows/sepia.md"
-
-  if [ ! -e "$skill" ] && [ ! -L "$skill" ]; then
-    echo "Antigravity disable aborted: skill not found." >&2
-    exit 1
-  fi
-  if [ ! -e "$workflow" ] && [ ! -L "$workflow" ]; then
-    echo "Antigravity disable aborted: workflow not found." >&2
-    exit 1
-  fi
-  if [ -e "$skill.disabled" ] || [ -L "$skill.disabled" ] || [ -e "$workflow.disabled" ] || [ -L "$workflow.disabled" ]; then
-    echo "Antigravity disable aborted: a .disabled target already exists." >&2
-    exit 1
-  fi
-
-  mv "$skill" "$skill.disabled"
-  mv "$workflow" "$workflow.disabled"
-)
-```
-
-This leaves `~/.sepia` in place for inspection. Deleting it is a separate manual decision.
 
 ## Layout
 
 ```text
 sepia/
+├── plugin.json              # Antigravity packaging
 ├── skills/
 │   ├── sepia/                # canonical skill (Agent Skills standard)
 │   │   ├── SKILL.md          # routing, operations, calibration rules, guardrails

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -90,7 +90,7 @@ Grok 也會自動找到既有的 Claude Code sepia 安裝；兩種方式都能�
 ### Antigravity
 
 ```bash
-# 直接從 GitHub 安裝
+# install directly from GitHub
 agy plugin install https://github.com/Nanako0129/sepia
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -47,7 +47,7 @@ sepia 把這些實測差距，連同 [`research/`](research/) 裡整理過的十
 
 ## 安裝
 
-四套工具都使用各自的原生 plugin installer。Antigravity 透過 `agy`，直接從 GitHub URL 安裝 plugin。全部預設採用 **user scope**：安裝一次，每個專案都能用。
+四套工具都使用各自的原生 plugin installer。全部預設採用 **user scope**：安裝一次，每個專案都能用。
 
 ### Claude Code
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -34,22 +34,20 @@ sepia 把這些實測差距，連同 [`research/`](research/) 裡整理過的十
 
 ## 操作入口
 
-完整 plugin package 會在 Claude Code、Codex 與 Grok Build 提供一個通用 router，以及四個可直接呼叫的操作入口：
+完整 plugin package 會在 Claude Code、Codex、Grok Build 與 Antigravity 提供一個通用 router，以及四個可直接呼叫的操作入口：
 
-| 操作 | Claude Code | Codex | Grok Build | 用途 |
-|---|---|---|---|---|
-| write | `/sepia-write` | `$sepia-write` | `/sepia-write` | 撰寫新內容 |
-| review | `/sepia-review` | `$sepia-review` | `/sepia-review` | 只診斷，不修改 |
-| refactor | `/sepia-refactor` | `$sepia-refactor` | `/sepia-refactor` | 在原文上做最小修改 |
-| recreate | `/sepia-recreate` | `$sepia-recreate` | `/sepia-recreate` | 依原始事實與意圖重新撰寫 |
+| 操作 | Claude Code | Codex | Grok Build | Antigravity | 用途 |
+|---|---|---|---|---|---|
+| write | `/sepia-write` | `$sepia-write` | `/sepia-write` | `/sepia-write` | 撰寫新內容 |
+| review | `/sepia-review` | `$sepia-review` | `/sepia-review` | `/sepia-review` | 只診斷，不修改 |
+| refactor | `/sepia-refactor` | `$sepia-refactor` | `/sepia-refactor` | `/sepia-refactor` | 在原文上做最小修改 |
+| recreate | `/sepia-recreate` | `$sepia-recreate` | `/sepia-recreate` | `/sepia-recreate` | 依原始事實與意圖重新撰寫 |
 
-通用 router 仍可透過 `/sepia`（Claude Code、Grok Build）或 `$sepia`（Codex）使用。操作 wrapper 依賴同一套 package 裡的正典 skill，不支援單獨安裝；請安裝完整 plugin package。這張表只記錄 package 語法；`v0.3.0` 尚未實測安裝後的 UI 與 runtime 行為。
-
-Antigravity 的 `v0.3.0` 手動安裝流程仍使用 `/sepia <operation>`，不提供獨立操作入口。
+通用 router 仍可透過 `/sepia`（Claude Code、Grok Build、Antigravity）或 `$sepia`（Codex）使用。操作 wrapper 依賴同一套 package 裡的正典 skill，不支援單獨安裝；請安裝完整 plugin package。這張表只記錄 package 語法；本次變更尚未實測安裝後的 UI 與 runtime 行為。
 
 ## 安裝
 
-Claude Code、Codex 與 Grok Build 使用各自的原生 plugin installer；Antigravity 依照下方的手動流程。全部預設採用 **user scope**：安裝一次，每個專案都能用。
+四套工具都使用各自的原生 plugin installer。Antigravity 透過 `agy`，直接從 GitHub URL 安裝 plugin。全部預設採用 **user scope**：安裝一次，每個專案都能用。
 
 ### Claude Code
 
@@ -91,28 +89,10 @@ Grok 也會自動找到既有的 Claude Code sepia 安裝；兩種方式都能�
 
 ### Antigravity
 
-Antigravity 沒有 marketplace。以下全新安裝固定使用目前的 `v0.3.0` release；任一目的地已存在就會中止：
-
 ```bash
-(
-  set -e
-
-  skill="$HOME/.gemini/config/skills/sepia"
-  workflow="$HOME/.gemini/antigravity/global_workflows/sepia.md"
-
-  if [ -e "$skill" ] || [ -L "$skill" ] || [ -e "$workflow" ] || [ -L "$workflow" ]; then
-    echo "Antigravity install aborted: move the existing skill and workflow aside first." >&2
-    exit 1
-  fi
-
-  git clone --branch v0.3.0 --depth 1 https://github.com/Nanako0129/sepia.git "$HOME/.sepia"
-  mkdir -p "$HOME/.gemini/config/skills" "$HOME/.gemini/antigravity/global_workflows"
-  cp -R "$HOME/.sepia/skills/sepia" "$skill"
-  cp "$HOME/.sepia/.agents/workflows/sepia.md" "$workflow"
-)
+# 直接從 GitHub 安裝
+agy plugin install https://github.com/Nanako0129/sepia
 ```
-
-Antigravity 沒有自動更新程式。要更新或回復舊版，先檢查想使用的 release，把目前的 clone、skill 與 workflow 移到自行命名的備份路徑，再用該 release tag 重做全新安裝。
 
 ### Skills CLI（替代方案，77+ 個 agent）
 
@@ -127,7 +107,7 @@ npx skills update -g                   # update
 
 ## 解除安裝
 
-Claude Code、Codex 與 Grok Build 各自使用原生指令：
+各套工具都使用原生指令：
 
 ```bash
 # Claude Code
@@ -138,41 +118,16 @@ codex plugin remove sepia@sepia
 
 # Grok Build
 grok plugin uninstall sepia
+
+# Antigravity
+agy plugin uninstall sepia
 ```
-
-Antigravity 透過重新命名停用 skill 與 workflow，之後仍可復原。如果來源缺少，或任一 `.disabled` 目的地已存在，預先檢查會在移動前中止：
-
-```bash
-(
-  set -e
-
-  skill="$HOME/.gemini/config/skills/sepia"
-  workflow="$HOME/.gemini/antigravity/global_workflows/sepia.md"
-
-  if [ ! -e "$skill" ] && [ ! -L "$skill" ]; then
-    echo "Antigravity disable aborted: skill not found." >&2
-    exit 1
-  fi
-  if [ ! -e "$workflow" ] && [ ! -L "$workflow" ]; then
-    echo "Antigravity disable aborted: workflow not found." >&2
-    exit 1
-  fi
-  if [ -e "$skill.disabled" ] || [ -L "$skill.disabled" ] || [ -e "$workflow.disabled" ] || [ -L "$workflow.disabled" ]; then
-    echo "Antigravity disable aborted: a .disabled target already exists." >&2
-    exit 1
-  fi
-
-  mv "$skill" "$skill.disabled"
-  mv "$workflow" "$workflow.disabled"
-)
-```
-
-這些指令會保留 `~/.sepia` 供檢查。是否刪除該 clone，請另行手動決定。
 
 ## 目錄結構
 
 ```text
 sepia/
+├── plugin.json              # Antigravity packaging
 ├── skills/
 │   ├── sepia/                # 正典 skill（Agent Skills standard）
 │   │   ├── SKILL.md          # routing、operations、calibration rules、guardrails

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "sepia",
+  "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate."
+}

--- a/research/platforms.md
+++ b/research/platforms.md
@@ -16,7 +16,7 @@
 | Claude Code | `~/.claude/skills/` / `.claude/skills/` / plugin `skills/`；plugin.json 在 `.claude-plugin/`；marketplace.json | 自動 + `/name` | 不用 |
 | Codex | `.agents/skills/`（cwd→repo root→`~`）；`.codex-plugin/plugin.json`；custom prompts 已 deprecated | 自動 + `$name` | 不用 |
 | Grok Build | 自動吃 Claude Code 的 skills/plugins/marketplaces；也有 `.grok/skills/` | 自動 + `/name` | 不用（零設定相容 Claude Code） |
-| Antigravity | `.agents/skills/`（與 Codex 同目錄）或 `~/.gemini/config/skills/`；rules/workflows 每檔 12k 字元上限（skills 不受限） | 純 description 觸發，無 slash；要 slash 需 workflow 包裝檔 | 內容不用 |
+| Antigravity | plugin `skills/`、`.agents/skills/`（與 Codex 同目錄）或 `~/.gemini/config/skills/` | 自動 + `/name` | 不用；workflows 已 deprecated |
 
 ## 建議 repo 佈局
 ```
@@ -24,12 +24,13 @@ repo/
 ├── skills/<name>/SKILL.md + references/   # canonical 唯一真相
 ├── .claude-plugin/plugin.json + marketplace.json
 ├── .codex-plugin/plugin.json              # "skills": "./skills/"
-├── .agents/workflows/<name>.md            # （可選）Antigravity slash 包裝
+├── .agents/workflows/<name>.md            # legacy Antigravity 相容；新入口直接用 skills
 └── README.md                              # native host installers + manual Antigravity copy
 ```
 - Claude Code plugin 的 skills 預設路徑就是 `./skills/` → 零設定
 - Grok 免安裝（自動發現 Claude 的安裝結果）
 - Codex 與 Antigravity 共用 `.agents/skills/` checkout
+- Antigravity CLI 1.1.22 的 `agy plugin validate .` 會處理 plugin `skills/` 下的五個 skill；內建 migration 文件把 workflows 標為 deprecated，skill 名稱本身就是 slash command
 
 官方文件：
 - https://agentskills.io/specification


### PR DESCRIPTION
## Summary

- add a root `plugin.json` so Antigravity can install sepia as a native plugin bundle
- replace the manual clone/copy instructions with `agy plugin install` and `agy plugin uninstall`
- document the Antigravity slash-command entries and package layout in both READMEs

## Verification

- `jq` manifest shape and JSON parsing checks
- `git diff --check`

The `agy` CLI is not available in this environment, so the native install and `agy plugin validate` were not run.