### PR TITLE
Release v0.4.0: voice-skill composition documented + #16 fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sepia",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
   "author": {
     "name": "Nanako Tsai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sepia",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
   "skills": "./skills/",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The complete plugin package gives Claude Code, Codex, Grok Build, and Antigravit
 
 The general `/sepia` (Claude Code, Grok Build, and Antigravity) or `$sepia` (Codex) router remains available. The operation wrappers depend on their sibling canonical skill, so standalone wrapper installation is unsupported; install the complete plugin package. This table documents package syntax; installed UI and runtime behavior were not exercised as part of this change.
 
+## Experimental: composing with voice skills
+
+Since v0.4.0, sepia defines an interface for stacking a voice or style skill on top of it — a minimalism method, a brand voice, a persona guide. It is opt-in: tell sepia the voice skill is in play, and it loads `references/voice-skills.md` over the normal route. Nothing is loaded, and no aesthetic is ever injected, unless you say so.
+
+The contract in short: sepia's architecture decisions come first, and the voice's moves are applied selectively (3–5 signature moves per piece, formula endings deliberately broken sometimes). Review reports the voice's known costs instead of fixing them away, while uniformity findings keep full strength: a voice does not excuse a metronome. On professional routes the venue still sets the register, and direct conflicts come back to you. The interface is grounded in one blind review experiment on a strict-minimalism specimen — a worked example, not measured evidence.
+
 ## Install
 
 All four tools use their native plugin installers. Every install defaults to **user scope** — install once, use it in every project.
@@ -131,7 +137,7 @@ sepia/
 ├── skills/
 │   ├── sepia/                # canonical skill (Agent Skills standard)
 │   │   ├── SKILL.md          # routing, operations, calibration rules, guardrails
-│   │   └── references/       # passes, rubric, fingerprints, and domain rules
+│   │   └── references/       # passes, rubric, fingerprints, domain rules, voice-skills (experimental)
 │   ├── sepia-write/SKILL.md  # thin fixed-operation wrappers
 │   ├── sepia-review/SKILL.md
 │   ├── sepia-refactor/SKILL.md

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -45,6 +45,12 @@ sepia 把這些實測差距，連同 [`research/`](research/) 裡整理過的十
 
 通用 router 仍可透過 `/sepia`（Claude Code、Grok Build、Antigravity）或 `$sepia`（Codex）使用。操作 wrapper 依賴同一套 package 裡的正典 skill，不支援單獨安裝；請安裝完整 plugin package。這張表只記錄 package 語法；本次變更尚未實測安裝後的 UI 與 runtime 行為。
 
+## 實驗性功能：疊加聲音 skill
+
+v0.4.0 起，sepia 定義了跟聲音／風格類 skill（極簡主義方法、品牌語調、persona 指南）疊加使用的介面。採 opt-in：你明講聲音 skill 在場，sepia 才會在原路由之上載入 `references/voice-skills.md`；不講就不載入，sepia 也永遠不會自己注入美學。
+
+條約摘要：sepia 的架構決策先行，聲音技法選擇性套用（每篇挑 3–5 招招牌技法，招牌結尾公式偶爾故意打破）。review 只回報聲音的已知代價、不代修，但均勻性 finding 不打折：聲音不能豁免節拍器。專業路由上 venue 仍定語域，直接衝突交回給你決定。這個介面的依據是一次極簡規格樣本的盲審實驗，屬單一案例，不是量測證據。
+
 ## 安裝
 
 四套工具都使用各自的原生 plugin installer。全部預設採用 **user scope**：安裝一次，每個專案都能用。
@@ -131,7 +137,7 @@ sepia/
 ├── skills/
 │   ├── sepia/                # 正典 skill（Agent Skills standard）
 │   │   ├── SKILL.md          # routing、operations、calibration rules、guardrails
-│   │   └── references/       # passes、rubric、fingerprints 與 domain rules
+│   │   └── references/       # passes、rubric、fingerprints、domain rules、voice-skills（實驗性）
 │   ├── sepia-write/SKILL.md  # 固定單一操作的薄 wrapper
 │   ├── sepia-review/SKILL.md
 │   ├── sepia-refactor/SKILL.md

--- a/skills/sepia/SKILL.md
+++ b/skills/sepia/SKILL.md
@@ -3,7 +3,7 @@ name: sepia
 description: Make AI-generated writing read as human-written, in fiction and in professional prose. Repairs the narrative architecture of fiction and stories (based on StoryScope, arXiv:2604.03136); routes professional text through domain rules for release notes, announcements, PR and issue replies, code-review comments, incident postmortems, tickets, work orders, technical articles, and blog posts. Four operations - write, review (diagnose AI tells without editing), refactor (minimal in-place edits), recreate (full rewrite). Use when asked to humanize, de-AI, unslop, or strip AI flavor from any text; when writing or revising any of these document types; or whenever output must not read as machine-written.
 license: MIT
 metadata:
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Sepia — de-AI writing

--- a/skills/sepia/references/voice-skills.md
+++ b/skills/sepia/references/voice-skills.md
@@ -28,7 +28,7 @@ A voice skill applied wholesale produces a house style, and a house style is a f
 |---|---|
 | Over-correction advisories on axes the voice deliberately pushes (a minimalism method driving interior access, sensory density, or thematic explicitness to the low extreme) | Expected: report them as the voice's known cost, and do not prescribe fixes against the user's chosen aesthetic. Escalate only if the user hasn't been told the trade-off |
 | Uniformity findings: the same sentence recipe in every paragraph, the key line always closing the paragraph, a complete setup-payoff ledger, a formula ending | Hard findings at full strength — a voice does not excuse a metronome |
-| Style-pass vocabulary and syntax hits | Hard findings at full strength |
+| Style-pass vocabulary and syntax hits | Unchanged — style-pass's own clustering thresholds and whitelists stay in force; a declared voice neither excuses nor hardens them |
 | Specificity and fact guardrails | Unchanged: never invent, voice or no voice |
 
 ## Worked example (single run, not measured evidence)


### PR DESCRIPTION
Release prep for v0.4.0.

- **Closes #16**: the voice-skills expectation table no longer hardens style-pass hits past style-pass's own clustering thresholds and whitelists — it now states style-pass applies unchanged under a declared voice.
- **READMEs** (English + zh-TW mirror): new "Experimental: composing with voice skills" section documenting the opt-in trigger, the composition contract, and the single-worked-example grounding; layout trees updated.
- **Version sync** to 0.4.0 across the Claude manifest, Codex manifest, and canonical SKILL.md metadata, per the v0.3.0 release convention.

`claude plugin validate` and `skills-ref validate` pass. Tag + GitHub release follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwGKATJ6u4rgWyLsbg4Grj