### PR TITLE
Install docs: any Agent Skills-compatible agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > De-AI writing at the layer that actually gives AI away. Fiction gets its narrative architecture repaired before anyone touches word choice; professional documents (release notes, PR replies, postmortems, tickets, technical articles) each get rules matched to their venue.
 
-A portable [Agent Skill](https://agentskills.io/specification): any agent that speaks the standard can load it, and the [Skills CLI](https://skills.sh) installs it on 77+ of them with one command. Claude Code, Codex, Grok Build, and Antigravity additionally get native plugin packaging, verified with live installs. One canonical `SKILL.md`, no per-platform forks. Four operations: **write**, **review** (diagnose only), **refactor** (minimal edits), **recreate** (full rewrite).
+A portable [Agent Skill](https://agentskills.io/specification): any agent that speaks the standard can load it, and the [Skills CLI](https://skills.sh), which supports 77+ agents, installs it with one command. Claude Code, Codex, Grok Build, and Antigravity additionally get native plugin packaging, install-verified on all four. One canonical `SKILL.md`, no per-platform forks. Four operations: **write**, **review** (diagnose only), **refactor** (minimal edits), **recreate** (full rewrite).
 
 ## Why another humanizer
 
@@ -53,19 +53,19 @@ The contract in short: sepia's architecture decisions come first, and the voice'
 
 ## Install
 
-Every install defaults to **user scope** — install once, use it in every project.
+Every command below is written for **user scope** — install once, use it in every project.
 
 ### Any agent (Skills CLI, 77+ agents)
 
 ```bash
 npx skills add Nanako0129/sepia -g     # -g = user scope; the default is project
-npx skills update -g                   # update
+npx skills update sepia -g             # update
 npx skills remove sepia -g             # uninstall
 ```
 
-Works on every agent the [Skills CLI](https://skills.sh) supports — Cursor, Cline, Windsurf, Copilot, OpenCode, goose, and more. Pick your agents when prompted. Runtime behavior outside the four platforms below has not been exercised by us; the skill is plain markdown under the Agent Skills standard, so file an issue if your agent trips on it.
+Installs on every agent the [Skills CLI](https://skills.sh) supports — Cursor, Cline, Windsurf, Copilot, OpenCode, goose, and more. Pick your agents when prompted. Runtime behavior outside the four platforms below has not been exercised by us; the skill is plain markdown under the Agent Skills standard, so file an issue if your agent trips on it.
 
-The four platforms below also have native plugin installers, each verified with a live install:
+The four platforms below have native plugin installers, each exercised with a live install. Verified means the install completes and the sepia entries appear; runtime behavior is as noted above.
 
 ### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > De-AI writing at the layer that actually gives AI away. Fiction gets its narrative architecture repaired before anyone touches word choice; professional documents (release notes, PR replies, postmortems, tickets, technical articles) each get rules matched to their venue.
 
-A portable [Agent Skill](https://agentskills.io/specification) for Claude Code, Codex, Grok Build, and Antigravity. One canonical `SKILL.md`, no per-platform forks. Four operations: **write**, **review** (diagnose only), **refactor** (minimal edits), **recreate** (full rewrite).
+A portable [Agent Skill](https://agentskills.io/specification): any agent that speaks the standard can load it, and the [Skills CLI](https://skills.sh) installs it on 77+ of them with one command. Claude Code, Codex, Grok Build, and Antigravity additionally get native plugin packaging, verified with live installs. One canonical `SKILL.md`, no per-platform forks. Four operations: **write**, **review** (diagnose only), **refactor** (minimal edits), **recreate** (full rewrite).
 
 ## Why another humanizer
 
@@ -53,7 +53,19 @@ The contract in short: sepia's architecture decisions come first, and the voice'
 
 ## Install
 
-All four tools use their native plugin installers. Every install defaults to **user scope** — install once, use it in every project.
+Every install defaults to **user scope** — install once, use it in every project.
+
+### Any agent (Skills CLI, 77+ agents)
+
+```bash
+npx skills add Nanako0129/sepia -g     # -g = user scope; the default is project
+npx skills update -g                   # update
+npx skills remove sepia -g             # uninstall
+```
+
+Works on every agent the [Skills CLI](https://skills.sh) supports — Cursor, Cline, Windsurf, Copilot, OpenCode, goose, and more. Pick your agents when prompted. Runtime behavior outside the four platforms below has not been exercised by us; the skill is plain markdown under the Agent Skills standard, so file an issue if your agent trips on it.
+
+The four platforms below also have native plugin installers, each verified with a live install:
 
 ### Claude Code
 
@@ -98,13 +110,6 @@ Grok also auto-discovers a Claude Code install of sepia if you have one; either 
 ```bash
 # install directly from GitHub
 agy plugin install https://github.com/Nanako0129/sepia
-```
-
-### Skills CLI (alternative, 77+ agents)
-
-```bash
-npx skills add Nanako0129/sepia -g     # -g = user scope; the default is project
-npx skills update -g                   # update
 ```
 
 ### Project scope (alternative)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 > 從真正會讓 AI 洩底的層次下手。小說先修敘事架構，再碰字句；專業文件（發版說明、PR 回覆、事故檢討、工單、技術文章）則按 venue 各用一套規則。
 
-這是一套可攜的 [Agent Skill](https://agentskills.io/specification)，支援 Claude Code、Codex、Grok Build 與 Antigravity。全平台共用唯一一份正典 `SKILL.md`，不另開平台分支。四種操作：**write**、**review**（只診斷）、**refactor**（最小修改）、**recreate**（整篇重寫）。
+這是一套可攜的 [Agent Skill](https://agentskills.io/specification)：任何支援這個標準的 agent 都能載入，[Skills CLI](https://skills.sh) 一行指令可裝到 77+ 家。Claude Code、Codex、Grok Build 與 Antigravity 另有原生 plugin 打包，且經實機安裝驗證。全平台共用唯一一份正典 `SKILL.md`，不另開平台分支。四種操作：**write**、**review**（只診斷）、**refactor**（最小修改）、**recreate**（整篇重寫）。
 
 ## 為什麼還需要另一個 humanizer
 
@@ -53,7 +53,19 @@ v0.4.0 起，sepia 定義了跟聲音／風格類 skill（極簡主義方法、�
 
 ## 安裝
 
-四套工具都使用各自的原生 plugin installer。全部預設採用 **user scope**：安裝一次，每個專案都能用。
+全部預設採用 **user scope**：安裝一次，每個專案都能用。
+
+### 任何 agent（Skills CLI，77+ 家）
+
+```bash
+npx skills add Nanako0129/sepia -g     # -g 才是 user scope；預設是 project
+npx skills update -g                   # 更新
+npx skills remove sepia -g             # 解除安裝
+```
+
+[Skills CLI](https://skills.sh) 支援的 agent 都能裝：Cursor、Cline、Windsurf、Copilot、OpenCode、goose 等，執行時選你的。四大平台以外的執行行為我們沒有實測過；skill 本體是 Agent Skills 標準下的純 markdown，你的 agent 若吃不動歡迎開 issue。
+
+下面四個平台另有原生 plugin installer，各自經實機安裝驗證：
 
 ### Claude Code
 
@@ -98,13 +110,6 @@ Grok 也會自動找到既有的 Claude Code sepia 安裝；兩種方式都能�
 ```bash
 # install directly from GitHub
 agy plugin install https://github.com/Nanako0129/sepia
-```
-
-### Skills CLI（替代方案，77+ 個 agent）
-
-```bash
-npx skills add Nanako0129/sepia -g     # -g = user scope; the default is project
-npx skills update -g                   # update
 ```
 
 ### Project scope（替代方案）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 > 從真正會讓 AI 洩底的層次下手。小說先修敘事架構，再碰字句；專業文件（發版說明、PR 回覆、事故檢討、工單、技術文章）則按 venue 各用一套規則。
 
-這是一套可攜的 [Agent Skill](https://agentskills.io/specification)：任何支援這個標準的 agent 都能載入，[Skills CLI](https://skills.sh) 一行指令可裝到 77+ 家。Claude Code、Codex、Grok Build 與 Antigravity 另有原生 plugin 打包，且經實機安裝驗證。全平台共用唯一一份正典 `SKILL.md`，不另開平台分支。四種操作：**write**、**review**（只診斷）、**refactor**（最小修改）、**recreate**（整篇重寫）。
+這是一套可攜的 [Agent Skill](https://agentskills.io/specification)：任何支援這個標準的 agent 都能載入；[Skills CLI](https://skills.sh)（支援 77+ 家 agent）一行指令就能裝。Claude Code、Codex、Grok Build 與 Antigravity 另有原生 plugin 打包，四家都實機裝過。全平台共用唯一一份正典 `SKILL.md`，不另開平台分支。四種操作：**write**、**review**（只診斷）、**refactor**（最小修改）、**recreate**（整篇重寫）。
 
 ## 為什麼還需要另一個 humanizer
 
@@ -53,19 +53,19 @@ v0.4.0 起，sepia 定義了跟聲音／風格類 skill（極簡主義方法、�
 
 ## 安裝
 
-全部預設採用 **user scope**：安裝一次，每個專案都能用。
+下列指令一律寫成 **user scope**：安裝一次，每個專案都能用。
 
 ### 任何 agent（Skills CLI，77+ 家）
 
 ```bash
 npx skills add Nanako0129/sepia -g     # -g 才是 user scope；預設是 project
-npx skills update -g                   # 更新
+npx skills update sepia -g             # 更新
 npx skills remove sepia -g             # 解除安裝
 ```
 
-[Skills CLI](https://skills.sh) 支援的 agent 都能裝：Cursor、Cline、Windsurf、Copilot、OpenCode、goose 等，執行時選你的。四大平台以外的執行行為我們沒有實測過；skill 本體是 Agent Skills 標準下的純 markdown，你的 agent 若吃不動歡迎開 issue。
+[Skills CLI](https://skills.sh) 支援的 agent 都能裝：Cursor、Cline、Windsurf、Copilot、OpenCode、goose 等；安裝時會問你要裝到哪幾家。四大平台以外的執行行為我們沒有實測過；skill 本體是 Agent Skills 標準下的純 markdown，你的 agent 若吃不動歡迎開 issue。
 
-下面四個平台另有原生 plugin installer，各自經實機安裝驗證：
+下面四個平台另有原生 plugin installer，各自實機裝過。驗證範圍是裝得完、sepia 入口出現；runtime 行為如上所述未逐一實測。
 
 ### Claude Code
 


### PR DESCRIPTION
Broadens the supported-agent claim honestly:

- Intro (both READMEs): any agent that speaks the Agent Skills standard can load sepia; the Skills CLI installs it on 77+ agents with one command. The four named platforms keep their distinct claim — native plugin packaging, verified with live installs.
- Skills CLI promoted from back-of-section alternative to the first install route, with update and remove commands (`npx skills remove sepia -g` verified against the CLI help).
- Untested-runtime caveat stated for agents outside the four, with an invitation to file issues.
- GitHub repo description updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwGKATJ6u4rgWyLsbg4Grj