### PR TITLE
feat: check that the manifests declaring a version agree on it

### DIFF
--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,17 @@
+name: version consistency
+
+# Runs on every push and pull request. The check is a single standard-library
+# script, so there is nothing to install and no lockfile to keep current.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # ubuntu-latest ships a python3, so no setup step is needed.
+      - run: python3 scripts/check_versions.py

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,17 +1,24 @@
 name: version consistency
 
-# Runs on every push and pull request. The check is a single standard-library
-# script, so there is nothing to install and no lockfile to keep current.
+# The checker and its tests are standard-library Python, so there is nothing
+# to install and no lockfile to keep current. ubuntu-latest ships a python3,
+# so no setup step is needed either.
 
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      # ubuntu-latest ships a python3, so no setup step is needed.
-      - run: python3 scripts/check_versions.py
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: unit tests for the checker
+        run: python3 -m unittest discover -s tests -v
+      - name: version consistency
+        run: python3 scripts/check_versions.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -158,15 +158,26 @@ def read_frontmatter_version(path, rel):
     except OSError as exc:
         return None, [(rel, f"unreadable: {exc}")]
 
-    if not text.startswith("---"):
+    # An editor-added UTF-8 BOM is invisible and tolerated by real
+    # frontmatter loaders; without stripping it the first line reads as
+    # \ufeff--- and a valid required file goes red on an invisible byte.
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
+    # Delimiters must be exactly --- as whole lines. Prefix matching let
+    # ---oops open and ---- close a "frontmatter" that a real YAML loader
+    # would refuse, keeping the required-core guard green after the
+    # declaration was broken (review round 7).
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
         return None, []
-    end = text.find("\n---", 3)
-    if end == -1:
+    close = next((i for i in range(1, len(lines)) if lines[i].rstrip() == "---"), None)
+    if close is None:
         return None, []
 
     in_metadata = False
     child_indent = None
-    for line in text[3:end].splitlines():
+    for line in lines[1:close]:
         if not line.strip():
             continue
         if line.lstrip().startswith("#"):

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -65,7 +65,10 @@ def _iter_files(root):
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
-        if any(part in SKIP_DIRS for part in path.parts):
+        # Only the directories BELOW root count: a repository checked out at
+        # /work/venv/sepia must not have every file skipped because an
+        # ancestor happens to be named venv (review round 5).
+        if any(part in SKIP_DIRS for part in path.relative_to(root).parts[:-1]):
             continue
         yield path
 
@@ -78,29 +81,17 @@ def _valid(value):
     return isinstance(value, str) and value != "" and value == value.strip()
 
 
-# Unquoted scalars that YAML reads as something other than a string. Per the
-# maintainer's direction the scanner stays a scanner: no YAML typing is
-# implemented, these are simply rejected with instructions to quote the value.
-_YAML_NONSTRING_RE = re.compile(
-    r"^(?:[-+]?(?:\d+|\d*\.\d+|\d+\.\d*)(?:[eE][-+]?\d+)?"
-    r"|0x[0-9a-fA-F]+|0o[0-7]+"
-    r"|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN)"
-    r"|true|True|TRUE|false|False|FALSE"
-    r"|yes|Yes|YES|no|No|NO|on|On|ON|off|Off|OFF"
-    r"|null|Null|NULL|~)$"
-)
-
-
 def _frontmatter_scalar(raw, rel):
     """(version_or_None, invalid) for one frontmatter version value.
 
     The shared value rules for both block and flow style. A quoted value is
     taken literally (minus the quotes) and then held to the same
     no-surrounding-whitespace rule as the JSON manifests. An unquoted value
-    that YAML would read as a number, boolean or null is rejected with
-    instructions to quote it, so `version: 1.0` cannot masquerade as the
-    string "1.0"; an unquoted value like 0.4.0 is a plain YAML string and is
-    accepted as such.
+    is invalid, full stop, with instructions to quote it. The first cut tried
+    to enumerate what YAML reads as non-strings and the enumeration had no
+    natural end (1.0, then true and null, then 0b10, then sexagesimal), so per
+    review the rule is inverted: quoting is the requirement, and this whole
+    class of finding closes permanently.
     """
     raw = raw.split(" #")[0].strip()
     if raw == "":
@@ -112,11 +103,7 @@ def _frontmatter_scalar(raw, rel):
         if value != value.strip():
             return None, [(rel, f"metadata.version {value!r} has surrounding whitespace")]
         return value, []
-    if _YAML_NONSTRING_RE.match(raw):
-        return None, [(rel,
-            f"metadata.version {raw} is unquoted and YAML would read it as a "
-            "number, boolean or null, not a string; quote it")]
-    return raw, []
+    return None, [(rel, f"metadata.version {raw} is unquoted; quote it")]
 
 
 def read_json_versions(path, rel):

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -71,7 +71,52 @@ def _iter_files(root):
 
 
 def _valid(value):
-    return isinstance(value, str) and value.strip() != ""
+    """A well-formed declaration: a non-empty string with no surrounding
+    whitespace. " 0.4.0 " is not the same advertised version as "0.4.0", and
+    normalizing it away would hide a manifest that differs from its siblings,
+    so it is reported instead of stripped (review round 4)."""
+    return isinstance(value, str) and value != "" and value == value.strip()
+
+
+# Unquoted scalars that YAML reads as something other than a string. Per the
+# maintainer's direction the scanner stays a scanner: no YAML typing is
+# implemented, these are simply rejected with instructions to quote the value.
+_YAML_NONSTRING_RE = re.compile(
+    r"^(?:[-+]?(?:\d+|\d*\.\d+|\d+\.\d*)(?:[eE][-+]?\d+)?"
+    r"|0x[0-9a-fA-F]+|0o[0-7]+"
+    r"|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN)"
+    r"|true|True|TRUE|false|False|FALSE"
+    r"|yes|Yes|YES|no|No|NO|on|On|ON|off|Off|OFF"
+    r"|null|Null|NULL|~)$"
+)
+
+
+def _frontmatter_scalar(raw, rel):
+    """(version_or_None, invalid) for one frontmatter version value.
+
+    The shared value rules for both block and flow style. A quoted value is
+    taken literally (minus the quotes) and then held to the same
+    no-surrounding-whitespace rule as the JSON manifests. An unquoted value
+    that YAML would read as a number, boolean or null is rejected with
+    instructions to quote it, so `version: 1.0` cannot masquerade as the
+    string "1.0"; an unquoted value like 0.4.0 is a plain YAML string and is
+    accepted as such.
+    """
+    raw = raw.split(" #")[0].strip()
+    if raw == "":
+        return None, [(rel, "metadata.version is present but empty")]
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        value = raw[1:-1]
+        if value.strip() == "":
+            return None, [(rel, "metadata.version is present but empty")]
+        if value != value.strip():
+            return None, [(rel, f"metadata.version {value!r} has surrounding whitespace")]
+        return value, []
+    if _YAML_NONSTRING_RE.match(raw):
+        return None, [(rel,
+            f"metadata.version {raw} is unquoted and YAML would read it as a "
+            "number, boolean or null, not a string; quote it")]
+    return raw, []
 
 
 def read_json_versions(path, rel):
@@ -92,16 +137,16 @@ def read_json_versions(path, rel):
     if isinstance(data, dict):
         if "version" in data:
             if _valid(data["version"]):
-                declared.append((rel, data["version"].strip()))
+                declared.append((rel, data["version"]))
             else:
-                invalid.append((rel, f"version is {data['version']!r}, not a non-empty string"))
+                invalid.append((rel, f"version is {data['version']!r}, not a non-empty string without surrounding whitespace"))
         for index, entry in enumerate(data.get("plugins") or []):
             if isinstance(entry, dict) and "version" in entry:
                 label = f"{rel} → plugins[{index}]"
                 if _valid(entry["version"]):
-                    declared.append((label, entry["version"].strip()))
+                    declared.append((label, entry["version"]))
                 else:
-                    invalid.append((label, f"version is {entry['version']!r}, not a non-empty string"))
+                    invalid.append((label, f"version is {entry['version']!r}, not a non-empty string without surrounding whitespace"))
     return declared, invalid
 
 
@@ -129,10 +174,7 @@ def _flow_metadata_version(rest, rel):
     match = re.search(r"(?:^|,)\s*version:\s*([^,]*)", inner)
     if not match:
         return None, []
-    raw = match.group(1).strip().strip("\"'")
-    if raw:
-        return raw, []
-    return None, [(rel, "metadata.version is present but empty")]
+    return _frontmatter_scalar(match.group(1), rel)
 
 
 def read_frontmatter_version(path, rel):
@@ -164,6 +206,11 @@ def read_frontmatter_version(path, rel):
     for line in text[3:end].splitlines():
         if not line.strip():
             continue
+        if line.lstrip().startswith("#"):
+            # A comment carries no structure at any indentation; an unindented
+            # one between metadata: and its children must not read as a new
+            # top-level key that closes the block (review round 4).
+            continue
         if not line[:1].isspace():
             head, sep, rest = line.partition(":")
             if head.strip() == "metadata" and sep:
@@ -187,10 +234,7 @@ def read_frontmatter_version(path, rel):
             continue
         stripped = line.strip()
         if stripped.startswith("version:"):
-            raw = stripped[len("version:"):].split(" #")[0].strip().strip("\"'")
-            if raw:
-                return raw, []
-            return None, [(rel, "metadata.version is present but empty")]
+            return _frontmatter_scalar(stripped[len("version:"):], rel)
     return None, []
 
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -37,6 +37,7 @@ Exit status is 0 when every declaration agrees and the required files all
 declare, 1 otherwise. The unit tests live in tests/test_check_versions.py.
 """
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -104,6 +105,36 @@ def read_json_versions(path, rel):
     return declared, invalid
 
 
+def _flow_metadata_version(rest, rel):
+    """The direct-child version of a flow-style `metadata: {...}` value.
+
+    Direct-child semantics are kept by deleting innermost `{...}` groups until
+    none remain: whatever survives is metadata's own level, and a version that
+    lived inside `compatibility: {...}` is gone before the scan. Values with
+    braces inside quoted strings are beyond a line scanner; if the braces do
+    not reduce cleanly the file is reported rather than guessed at.
+    """
+    if not (rest.startswith("{") and rest.endswith("}")):
+        return None, [(rel, f"metadata is {rest!r}, neither a block nor a {{...}} flow mapping")]
+
+    inner = rest[1:-1]
+    while True:
+        reduced = re.sub(r"\{[^{}]*\}", "", inner)
+        if reduced == inner:
+            break
+        inner = reduced
+    if "{" in inner or "}" in inner:
+        return None, [(rel, "metadata flow mapping has unbalanced braces; use block style")]
+
+    match = re.search(r"(?:^|,)\s*version:\s*([^,]*)", inner)
+    if not match:
+        return None, []
+    raw = match.group(1).strip().strip("\"'")
+    if raw:
+        return raw, []
+    return None, [(rel, "metadata.version is present but empty")]
+
+
 def read_frontmatter_version(path, rel):
     """(version_or_None, invalid) for one SKILL.md.
 
@@ -134,7 +165,17 @@ def read_frontmatter_version(path, rel):
         if not line.strip():
             continue
         if not line[:1].isspace():
-            in_metadata = line.rstrip() == "metadata:"
+            head, sep, rest = line.partition(":")
+            if head.strip() == "metadata" and sep:
+                rest = rest.split(" #")[0].strip()
+                if rest:
+                    # Flow syntax: metadata: {version: "0.4.0", ...}. Valid
+                    # YAML, and a formatter may produce it, so a version here
+                    # must be found rather than reported missing.
+                    return _flow_metadata_version(rest, rel)
+                in_metadata = True
+            else:
+                in_metadata = False
             child_indent = None
             continue
         if not in_metadata:

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -107,11 +107,15 @@ def read_json_versions(path, rel):
 def read_frontmatter_version(path, rel):
     """(version_or_None, invalid) for one SKILL.md.
 
-    Only `version:` inside the top-level `metadata:` block counts. A line scan
-    with one bit of state rather than a YAML parser: entering the frontmatter's
-    `metadata:` key sets it, the next top-level key clears it. Anything else
-    named version elsewhere in the frontmatter (say `compatibility.version`)
-    belongs to that other key, not to the skill.
+    Only a `version:` that is a DIRECT child of the top-level `metadata:` block
+    counts. A line scan rather than a YAML parser, carrying two pieces of
+    state: entering the frontmatter's `metadata:` key opens the block and the
+    next top-level key closes it, and the block's first child fixes the
+    indentation that direct children must sit at. Anything deeper belongs to a
+    nested key (say `metadata.compatibility.version`) and anything named
+    version under some other top-level key belongs to that key, so neither is
+    the skill's version. Blank lines carry no structure and are skipped rather
+    than being mistaken for a top-level key.
     """
     try:
         text = path.read_text(encoding="utf-8")
@@ -125,17 +129,27 @@ def read_frontmatter_version(path, rel):
         return None, []
 
     in_metadata = False
+    child_indent = None
     for line in text[3:end].splitlines():
+        if not line.strip():
+            continue
         if not line[:1].isspace():
             in_metadata = line.rstrip() == "metadata:"
+            child_indent = None
             continue
-        if in_metadata:
-            stripped = line.strip()
-            if stripped.startswith("version:"):
-                raw = stripped[len("version:"):].split(" #")[0].strip().strip("\"'")
-                if raw:
-                    return raw, []
-                return None, [(rel, "metadata.version is present but empty")]
+        if not in_metadata:
+            continue
+        indent = len(line) - len(line.lstrip())
+        if child_indent is None:
+            child_indent = indent
+        if indent != child_indent:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("version:"):
+            raw = stripped[len("version:"):].split(" #")[0].strip().strip("\"'")
+            if raw:
+                return raw, []
+            return None, [(rel, "metadata.version is present but empty")]
     return None, []
 
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -137,38 +137,14 @@ def read_json_versions(path, rel):
     return declared, invalid
 
 
-def _flow_metadata_version(rest, rel):
-    """The direct-child version of a flow-style `metadata: {...}` value.
-
-    Direct-child semantics are kept by deleting innermost `{...}` groups until
-    none remain: whatever survives is metadata's own level, and a version that
-    lived inside `compatibility: {...}` is gone before the scan. Values with
-    braces inside quoted strings are beyond a line scanner; if the braces do
-    not reduce cleanly the file is reported rather than guessed at.
-    """
-    if not (rest.startswith("{") and rest.endswith("}")):
-        return None, [(rel, f"metadata is {rest!r}, neither a block nor a {{...}} flow mapping")]
-
-    inner = rest[1:-1]
-    while True:
-        reduced = re.sub(r"\{[^{}]*\}", "", inner)
-        if reduced == inner:
-            break
-        inner = reduced
-    if "{" in inner or "}" in inner:
-        return None, [(rel, "metadata flow mapping has unbalanced braces; use block style")]
-
-    match = re.search(r"(?:^|,)\s*version:\s*([^,]*)", inner)
-    if not match:
-        return None, []
-    return _frontmatter_scalar(match.group(1), rel)
-
-
 def read_frontmatter_version(path, rel):
     """(version_or_None, invalid) for one SKILL.md.
 
-    Only a `version:` that is a DIRECT child of the top-level `metadata:` block
-    counts. A line scan rather than a YAML parser, carrying two pieces of
+    Only a `version:` that is a DIRECT child of a block-style top-level
+    `metadata:` counts. Inline metadata (flow mappings, scalars) is refused
+    with instructions to use block style: two review rounds of quoted-span and
+    nested-brace edge cases traced back to hand-parsing flow, and the refusal
+    is loud and names its own fix. A line scan rather than a YAML parser, carrying two pieces of
     state: entering the frontmatter's `metadata:` key opens the block and the
     next top-level key closes it, and the block's first child fixes the
     indentation that direct children must sit at. Anything deeper belongs to a
@@ -203,10 +179,15 @@ def read_frontmatter_version(path, rel):
             if head.strip() == "metadata" and sep:
                 rest = rest.split(" #")[0].strip()
                 if rest:
-                    # Flow syntax: metadata: {version: "0.4.0", ...}. Valid
-                    # YAML, and a formatter may produce it, so a version here
-                    # must be found rather than reported missing.
-                    return _flow_metadata_version(rest, rel)
+                    # An inline value (flow mapping or scalar) is refused, not
+                    # parsed. The flow parser this replaces produced two review
+                    # findings of its own (nested braces, then quoted spans),
+                    # and the failure a formatter causes here is loud and names
+                    # its own fix, while a hand-parsed flow mapping fails
+                    # quietly and wrong (review round 6).
+                    return None, [(rel,
+                        "metadata is declared inline; flow-style metadata is "
+                        "not supported, use block style")]
                 in_metadata = True
             else:
                 in_metadata = False

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Fail when the files that declare a version disagree about which one it is.
+
+Three files carry sepia's version today: the Claude and Codex plugin manifests
+and the canonical SKILL.md's frontmatter. They have never disagreed. This is a
+guard for later, not a fix for now.
+
+It matters because the failure would be silent. Nothing breaks at install time
+when one manifest is a version behind; the wrong number just gets advertised,
+and a version number is exactly the claim a reader uses to judge whether a
+project is still maintained.
+
+Discovery rather than a fixed list, so the guard grows with the repository.
+The packaging surface has already grown once, with the Antigravity manifest in
+Nanako0129/sepia#14, and the root plugin.json and both marketplace.json files
+carry no version today. If any of them gains one later, it is checked from that
+moment without anyone remembering to add it here. Files with no version are
+reported, not failed: absent is a legitimate state, and printing them is how a
+maintainer sees what the scan actually looked at.
+
+Standard library only, by design. The repository has no lockfiles and this
+should not be the reason it gets one.
+
+    python3 scripts/check_versions.py
+
+Exit status is 0 when every declaration agrees, 1 otherwise.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Directories that never hold a manifest worth checking.
+SKIP_DIRS = {".git", "node_modules", ".venv", "venv", "__pycache__", ".mypy_cache"}
+
+# Any file with one of these names is treated as a packaging manifest, wherever
+# it sits. That is the point: a manifest added in a new directory is found.
+MANIFEST_NAMES = {"plugin.json", "marketplace.json"}
+
+# A skill declares its version in YAML frontmatter, under `metadata`. Parsed by
+# hand rather than with PyYAML to keep the dependency count at zero; the shape
+# is fixed and simple enough that a line scan is honest here.
+FRONTMATTER_VERSION_RE = re.compile(r"^\s+version:\s*[\"']?([^\"'\s]+)[\"']?\s*$", re.M)
+
+
+class ManifestError(Exception):
+    """A file that should have been readable was not."""
+
+
+def _iter_files(root):
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        yield path
+
+
+def _rel(path):
+    return str(path.relative_to(ROOT))
+
+
+def read_json_versions(path):
+    """Every version a JSON manifest declares, as (label, version) pairs.
+
+    Both shapes are covered: a top-level `version`, and a `version` on each
+    entry of a `plugins` array, which is where a marketplace file would put it.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"{_rel(path)}: {exc}") from exc
+
+    found = []
+    if isinstance(data, dict):
+        if isinstance(data.get("version"), str):
+            found.append((_rel(path), data["version"]))
+        for index, entry in enumerate(data.get("plugins") or []):
+            if isinstance(entry, dict) and isinstance(entry.get("version"), str):
+                found.append((f"{_rel(path)} → plugins[{index}]", entry["version"]))
+    return found
+
+
+def read_frontmatter_version(path):
+    """The version in a SKILL.md's frontmatter, or None if it declares none."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ManifestError(f"{_rel(path)}: {exc}") from exc
+
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    match = FRONTMATTER_VERSION_RE.search(text[3:end])
+    return match.group(1) if match else None
+
+
+def scan(root):
+    """Walk the repository once. Returns (declared, silent).
+
+    declared: [(label, version)] for everything that states a version.
+    silent:   [label] for manifests and skills that state none, which is fine
+              and is printed so the scan's reach stays visible.
+    """
+    declared, silent = [], []
+
+    for path in _iter_files(root):
+        if path.name in MANIFEST_NAMES:
+            versions = read_json_versions(path)
+            if versions:
+                declared.extend(versions)
+            else:
+                silent.append(_rel(path))
+        elif path.name == "SKILL.md":
+            version = read_frontmatter_version(path)
+            if version:
+                declared.append((_rel(path), version))
+            else:
+                silent.append(_rel(path))
+
+    return declared, silent
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    if argv in (["-h"], ["--help"]):
+        print(__doc__.strip())
+        return 0
+    if argv:
+        print(f"version check: takes no arguments, got {' '.join(argv)}", file=sys.stderr)
+        return 2
+
+    try:
+        declared, silent = scan(ROOT)
+    except ManifestError as exc:
+        print(f"version check: unreadable manifest: {exc}", file=sys.stderr)
+        return 1
+
+    width = max((len(label) for label in [l for l, _ in declared] + silent), default=0)
+    for label, version in declared:
+        print(f"  {label.ljust(width)}  {version}")
+    for label in silent:
+        print(f"  {label.ljust(width)}  (no version declared)")
+
+    if not declared:
+        # Not a pass. Discovery finding nothing means the layout moved and this
+        # guard stopped guarding, which is the one failure it cannot report as
+        # a mismatch.
+        print(
+            "\nversion check: FAILED, no file declares a version.\n"
+            "Either the manifests moved or this script's discovery is out of date.",
+            file=sys.stderr,
+        )
+        return 1
+
+    versions = {version for _, version in declared}
+    if len(versions) > 1:
+        print(
+            f"\nversion check: FAILED, {len(versions)} different versions declared: "
+            f"{', '.join(sorted(versions))}.\n"
+            "Every file above that states a version must state the same one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    only = versions.pop()
+    print(f"\nversion check: OK, {len(declared)} declarations, all {only}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -10,23 +10,33 @@ when one manifest is a version behind; the wrong number just gets advertised,
 and a version number is exactly the claim a reader uses to judge whether a
 project is still maintained.
 
-Discovery rather than a fixed list, so the guard grows with the repository.
-The packaging surface has already grown once, with the Antigravity manifest in
-Nanako0129/sepia#14, and the root plugin.json and both marketplace.json files
-carry no version today. If any of them gains one later, it is checked from that
-moment without anyone remembering to add it here. Files with no version are
-reported, not failed: absent is a legitimate state, and printing them is how a
-maintainer sees what the scan actually looked at.
+Two rules, covering the two ways this can rot:
+
+1. Discovery. Any file named plugin.json or marketplace.json is read wherever
+   it sits, for a top-level `version` and for one on each entry of a `plugins`
+   array, and every SKILL.md's frontmatter is read for `metadata.version`. A
+   manifest that gains a version later is checked from that moment. A `version`
+   key that exists but is not a non-empty string fails: a field someone edited
+   into a number or an empty value is a mistake, not an absence.
+
+2. A required core. The three files that declare the version today must keep
+   declaring it. Without this, deleting one of them would just shrink the
+   agreeing set and the check would stay green, which is precisely the silent
+   failure it exists to catch.
+
+Files that declare nothing and are not required are listed, not failed: absent
+is a legitimate state there, and printing them keeps the scan's reach visible.
+Discovery finding nothing at all is likewise a failure, not a pass.
 
 Standard library only, by design. The repository has no lockfiles and this
 should not be the reason it gets one.
 
     python3 scripts/check_versions.py
 
-Exit status is 0 when every declaration agrees, 1 otherwise.
+Exit status is 0 when every declaration agrees and the required files all
+declare, 1 otherwise. The unit tests live in tests/test_check_versions.py.
 """
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -39,14 +49,15 @@ SKIP_DIRS = {".git", "node_modules", ".venv", "venv", "__pycache__", ".mypy_cach
 # it sits. That is the point: a manifest added in a new directory is found.
 MANIFEST_NAMES = {"plugin.json", "marketplace.json"}
 
-# A skill declares its version in YAML frontmatter, under `metadata`. Parsed by
-# hand rather than with PyYAML to keep the dependency count at zero; the shape
-# is fixed and simple enough that a line scan is honest here.
-FRONTMATTER_VERSION_RE = re.compile(r"^\s+version:\s*[\"']?([^\"'\s]+)[\"']?\s*$", re.M)
-
-
-class ManifestError(Exception):
-    """A file that should have been readable was not."""
+# The files that carry the version today. Discovery still scans everything;
+# these additionally MUST declare one, so a deleted or mistyped field fails
+# instead of quietly shrinking the agreeing set. When the layout changes on
+# purpose, change this list in the same commit.
+REQUIRED = (
+    ".claude-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "skills/sepia/SKILL.md",
+)
 
 
 def _iter_files(root):
@@ -58,71 +69,144 @@ def _iter_files(root):
         yield path
 
 
-def _rel(path):
-    return str(path.relative_to(ROOT))
+def _valid(value):
+    return isinstance(value, str) and value.strip() != ""
 
 
-def read_json_versions(path):
-    """Every version a JSON manifest declares, as (label, version) pairs.
+def read_json_versions(path, rel):
+    """(declared, invalid) for one JSON manifest.
 
-    Both shapes are covered: a top-level `version`, and a `version` on each
-    entry of a `plugins` array, which is where a marketplace file would put it.
+    declared: [(label, version)] for every well-formed declaration.
+    invalid:  [(label, reason)] for every `version` key that exists but is not
+              a non-empty string. Present-but-wrong is an error, never an
+              absence: treating it as absence is how a deleted or mistyped
+              field slips through.
     """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise ManifestError(f"{_rel(path)}: {exc}") from exc
+        return [], [(rel, f"unreadable: {exc}")]
 
-    found = []
+    declared, invalid = [], []
     if isinstance(data, dict):
-        if isinstance(data.get("version"), str):
-            found.append((_rel(path), data["version"]))
+        if "version" in data:
+            if _valid(data["version"]):
+                declared.append((rel, data["version"].strip()))
+            else:
+                invalid.append((rel, f"version is {data['version']!r}, not a non-empty string"))
         for index, entry in enumerate(data.get("plugins") or []):
-            if isinstance(entry, dict) and isinstance(entry.get("version"), str):
-                found.append((f"{_rel(path)} → plugins[{index}]", entry["version"]))
-    return found
+            if isinstance(entry, dict) and "version" in entry:
+                label = f"{rel} → plugins[{index}]"
+                if _valid(entry["version"]):
+                    declared.append((label, entry["version"].strip()))
+                else:
+                    invalid.append((label, f"version is {entry['version']!r}, not a non-empty string"))
+    return declared, invalid
 
 
-def read_frontmatter_version(path):
-    """The version in a SKILL.md's frontmatter, or None if it declares none."""
+def read_frontmatter_version(path, rel):
+    """(version_or_None, invalid) for one SKILL.md.
+
+    Only `version:` inside the top-level `metadata:` block counts. A line scan
+    with one bit of state rather than a YAML parser: entering the frontmatter's
+    `metadata:` key sets it, the next top-level key clears it. Anything else
+    named version elsewhere in the frontmatter (say `compatibility.version`)
+    belongs to that other key, not to the skill.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
-        raise ManifestError(f"{_rel(path)}: {exc}") from exc
+        return None, [(rel, f"unreadable: {exc}")]
 
     if not text.startswith("---"):
-        return None
+        return None, []
     end = text.find("\n---", 3)
     if end == -1:
-        return None
-    match = FRONTMATTER_VERSION_RE.search(text[3:end])
-    return match.group(1) if match else None
+        return None, []
+
+    in_metadata = False
+    for line in text[3:end].splitlines():
+        if not line[:1].isspace():
+            in_metadata = line.rstrip() == "metadata:"
+            continue
+        if in_metadata:
+            stripped = line.strip()
+            if stripped.startswith("version:"):
+                raw = stripped[len("version:"):].split(" #")[0].strip().strip("\"'")
+                if raw:
+                    return raw, []
+                return None, [(rel, "metadata.version is present but empty")]
+    return None, []
 
 
 def scan(root):
-    """Walk the repository once. Returns (declared, silent).
-
-    declared: [(label, version)] for everything that states a version.
-    silent:   [label] for manifests and skills that state none, which is fine
-              and is printed so the scan's reach stays visible.
-    """
-    declared, silent = [], []
+    """Walk the repository once. Returns (declared, silent, invalid)."""
+    declared, silent, invalid = [], [], []
 
     for path in _iter_files(root):
+        rel = path.relative_to(root).as_posix()  # forward slashes on Windows too
         if path.name in MANIFEST_NAMES:
-            versions = read_json_versions(path)
-            if versions:
-                declared.extend(versions)
-            else:
-                silent.append(_rel(path))
+            found, bad = read_json_versions(path, rel)
+            invalid.extend(bad)
+            if found:
+                declared.extend(found)
+            elif not bad:
+                silent.append(rel)
         elif path.name == "SKILL.md":
-            version = read_frontmatter_version(path)
+            version, bad = read_frontmatter_version(path, rel)
+            invalid.extend(bad)
             if version:
-                declared.append((_rel(path), version))
-            else:
-                silent.append(_rel(path))
+                declared.append((rel, version))
+            elif not bad:
+                silent.append(rel)
 
-    return declared, silent
+    return declared, silent, invalid
+
+
+def run(root, required=REQUIRED):
+    """The whole check, as (exit_code, report_text). main() just prints it."""
+    declared, silent, invalid = scan(root)
+    lines, failures = [], []
+
+    labels = [label for label, _ in declared]
+    width = max((len(label) for label in labels + silent), default=0)
+    for label, version in declared:
+        lines.append(f"  {label.ljust(width)}  {version}")
+    for label in silent:
+        lines.append(f"  {label.ljust(width)}  (no version declared)")
+
+    for label, reason in invalid:
+        failures.append(f"{label}: {reason}")
+
+    for rel in required:
+        if rel not in labels:
+            failures.append(
+                f"{rel}: required to declare a version and does not. If the layout "
+                "changed on purpose, update REQUIRED in scripts/check_versions.py."
+            )
+
+    if not declared and not failures:
+        failures.append(
+            "no file declares a version. Either the manifests moved or this "
+            "script's discovery is out of date."
+        )
+
+    versions = {version for _, version in declared}
+    if len(versions) > 1:
+        failures.append(
+            f"{len(versions)} different versions declared: {', '.join(sorted(versions))}. "
+            "Every file that states a version must state the same one."
+        )
+
+    if failures:
+        lines.append("")
+        lines.append("version check: FAILED")
+        lines.extend(f"  - {failure}" for failure in failures)
+        return 1, "\n".join(lines)
+
+    lines.append("")
+    lines.append(f"version check: OK, {len(declared)} declarations, all {versions.pop()}.")
+    return 0, "\n".join(lines)
 
 
 def main(argv=None):
@@ -134,42 +218,9 @@ def main(argv=None):
         print(f"version check: takes no arguments, got {' '.join(argv)}", file=sys.stderr)
         return 2
 
-    try:
-        declared, silent = scan(ROOT)
-    except ManifestError as exc:
-        print(f"version check: unreadable manifest: {exc}", file=sys.stderr)
-        return 1
-
-    width = max((len(label) for label in [l for l, _ in declared] + silent), default=0)
-    for label, version in declared:
-        print(f"  {label.ljust(width)}  {version}")
-    for label in silent:
-        print(f"  {label.ljust(width)}  (no version declared)")
-
-    if not declared:
-        # Not a pass. Discovery finding nothing means the layout moved and this
-        # guard stopped guarding, which is the one failure it cannot report as
-        # a mismatch.
-        print(
-            "\nversion check: FAILED, no file declares a version.\n"
-            "Either the manifests moved or this script's discovery is out of date.",
-            file=sys.stderr,
-        )
-        return 1
-
-    versions = {version for _, version in declared}
-    if len(versions) > 1:
-        print(
-            f"\nversion check: FAILED, {len(versions)} different versions declared: "
-            f"{', '.join(sorted(versions))}.\n"
-            "Every file above that states a version must state the same one.",
-            file=sys.stderr,
-        )
-        return 1
-
-    only = versions.pop()
-    print(f"\nversion check: OK, {len(declared)} declarations, all {only}.")
-    return 0
+    code, report = run(ROOT)
+    print(report, file=sys.stderr if code else sys.stdout)
+    return code
 
 
 if __name__ == "__main__":

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -194,6 +194,96 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("3 declarations, all 0.4.0", report)
 
+    # --- review round four: whitespace, comments, unquoted scalars ----------
+
+    def test_surrounding_whitespace_in_a_json_version_is_invalid_not_normalized(self):
+        # " 0.4.0 " is not the same advertised version as "0.4.0"; stripping
+        # it away would hide a manifest that differs from its siblings.
+        code, report = self.run_check(
+            {".codex-plugin/plugin.json": {"name": "sepia", "version": " 0.4.0 "}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("surrounding whitespace", report)
+
+    def test_an_unindented_comment_does_not_close_the_metadata_block(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "# version used for packaging", '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
+
+    def test_an_indented_comment_does_not_fix_the_child_indentation(self):
+        # If the comment were treated as the first child, its indentation
+        # would become the required level and the real version would be
+        # skipped as "wrong depth".
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "    # a deeper comment", '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+
+    def test_an_unquoted_numeric_version_is_rejected_with_quote_instructions(self):
+        # YAML reads version: 1.0 as a number; the scanner stays a scanner and
+        # rejects it rather than implementing YAML typing.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "  version: 1.0"]
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("quote it", report)
+
+    def test_unquoted_booleans_and_nulls_are_rejected_too(self):
+        for value in ("true", "null", "~", "off"):
+            code, report = self.run_check(
+                {
+                    "skills/sepia/SKILL.md": skill_md(
+                        ["name: sepia", "metadata:", f"  version: {value}"]
+                    )
+                }
+            )
+            self.assertEqual(code, 1, f"version: {value} should be rejected")
+            self.assertIn("quote it", report)
+
+    def test_an_unquoted_dotted_version_is_a_plain_yaml_string_and_accepted(self):
+        # 0.4.0 is not a valid YAML number, so unquoted it is already a
+        # string; rejecting it would be a false red.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "  version: 0.4.0"]
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+
+    def test_quoted_whitespace_in_frontmatter_is_held_to_the_json_rule(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  version: " 0.4.0 "']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("surrounding whitespace", report)
+
+    def test_flow_style_unquoted_number_is_rejected_too(self):
+        code, report = self.run_check(
+            {"skills/sepia/SKILL.md": skill_md(["name: sepia", "metadata: {version: 1.0}"])}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("quote it", report)
+
     # --- flow-style metadata ------------------------------------------------
 
     def test_flow_style_metadata_is_read_not_reported_missing(self):

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -257,14 +257,6 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("surrounding whitespace", report)
 
-    def test_flow_style_unquoted_values_are_rejected_too(self):
-        for value in ("1.0", "0.4.0"):
-            code, report = self.run_check(
-                {"skills/sepia/SKILL.md": skill_md(["name: sepia", f"metadata: {{version: {value}}}"])}
-            )
-            self.assertEqual(code, 1, f"flow version: {value} should be rejected")
-            self.assertIn("quote it", report)
-
     def test_a_repository_under_a_skipped_ancestor_name_still_scans(self):
         # Review round five: SKIP_DIRS applied to absolute path parts made a
         # checkout at .../venv/<repo> skip every file and report all required
@@ -280,55 +272,26 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("3 declarations, all 0.4.0", report)
 
-    # --- flow-style metadata ------------------------------------------------
+    # --- inline metadata is refused, not parsed (round 6) -------------------
 
-    def test_flow_style_metadata_is_read_not_reported_missing(self):
-        # Review case, round three: metadata: {version: "0.4.0"} is valid YAML
-        # that a formatter may produce. It must be read, not failed as a
-        # missing required declaration.
-        code, report = self.run_check(
-            {
-                "skills/sepia/SKILL.md": skill_md(
-                    ["name: sepia", 'metadata: {version: "0.4.0"}']
-                )
-            }
-        )
-        self.assertEqual(code, 0)
-        self.assertIn("3 declarations, all 0.4.0", report)
-
-    def test_flow_style_keeps_direct_child_semantics(self):
-        # A version nested inside a flow compatibility mapping is not the
-        # skill's version; the direct child next to it is.
-        code, report = self.run_check(
-            {
-                "skills/sepia/SKILL.md": skill_md(
-                    [
-                        "name: sepia",
-                        'metadata: {compatibility: {version: "9.9.9"}, version: "0.4.0"}',
-                    ]
-                )
-            }
-        )
-        self.assertEqual(code, 0)
-        self.assertNotIn("9.9.9", report)
-
-    def test_flow_style_with_only_a_nested_version_declares_none(self):
-        code, report = self.run_check(
-            {
-                "skills/sepia/SKILL.md": skill_md(
-                    ["name: sepia", 'metadata: {compatibility: {version: "9.9.9"}}']
-                )
-            }
-        )
-        self.assertEqual(code, 1)
-        self.assertIn("skills/sepia/SKILL.md: required", report)
-
-    def test_a_scalar_metadata_value_is_reported_not_guessed_at(self):
-        code, report = self.run_check(
-            {"skills/sepia/SKILL.md": skill_md(["name: sepia", "metadata: oops"])}
-        )
-        self.assertEqual(code, 1)
-        self.assertIn("neither a block nor a", report)
+    def test_inline_metadata_is_refused_with_block_style_instructions(self):
+        # The flow parser produced two review findings of its own (nested
+        # braces, then version-like text inside a quoted value). Deleted per
+        # review: any inline metadata value is refused with a message naming
+        # the fix. The last case is the round-six finding itself: without the
+        # deletion, text inside a quoted scalar was mistaken for a version key.
+        for inline in (
+            '{version: "0.4.0"}',
+            '{compatibility: {version: "9.9.9"}, version: "0.4.0"}',
+            '{version: 1.0}',
+            'oops',
+            '{description: "current, version: 9.9.9"}',
+        ):
+            code, report = self.run_check(
+                {"skills/sepia/SKILL.md": skill_md(["name: sepia", f"metadata: {inline}"])}
+            )
+            self.assertEqual(code, 1, f"metadata: {inline} should be refused")
+            self.assertIn("use block style", report)
 
     def test_an_empty_metadata_version_fails(self):
         code, report = self.run_check(

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -151,6 +151,49 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertNotIn("9.9.9", report)
 
+    def test_a_nested_version_inside_metadata_is_not_the_skill_version(self):
+        # Review case, round two: metadata.compatibility.version must not
+        # shadow metadata's own direct child. Only the direct child counts.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    [
+                        "name: sepia",
+                        "metadata:",
+                        "  compatibility:",
+                        '    version: "9.9.9"',
+                        '  version: "0.4.0"',
+                    ]
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("9.9.9", report)
+
+    def test_only_a_nested_version_means_the_skill_declares_none(self):
+        # With nothing but metadata.compatibility.version, the skill declares
+        # no version of its own, and since it is required that fails.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "  compatibility:", '    version: "9.9.9"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("skills/sepia/SKILL.md: required", report)
+
+    def test_a_blank_line_inside_metadata_does_not_close_the_block(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "", '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
+
     def test_an_empty_metadata_version_fails(self):
         code, report = self.run_check(
             {

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -194,6 +194,56 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("3 declarations, all 0.4.0", report)
 
+    # --- flow-style metadata ------------------------------------------------
+
+    def test_flow_style_metadata_is_read_not_reported_missing(self):
+        # Review case, round three: metadata: {version: "0.4.0"} is valid YAML
+        # that a formatter may produce. It must be read, not failed as a
+        # missing required declaration.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", 'metadata: {version: "0.4.0"}']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
+
+    def test_flow_style_keeps_direct_child_semantics(self):
+        # A version nested inside a flow compatibility mapping is not the
+        # skill's version; the direct child next to it is.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    [
+                        "name: sepia",
+                        'metadata: {compatibility: {version: "9.9.9"}, version: "0.4.0"}',
+                    ]
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("9.9.9", report)
+
+    def test_flow_style_with_only_a_nested_version_declares_none(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", 'metadata: {compatibility: {version: "9.9.9"}}']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("skills/sepia/SKILL.md: required", report)
+
+    def test_a_scalar_metadata_value_is_reported_not_guessed_at(self):
+        code, report = self.run_check(
+            {"skills/sepia/SKILL.md": skill_md(["name: sepia", "metadata: oops"])}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("neither a block nor a", report)
+
     def test_an_empty_metadata_version_fails(self):
         code, report = self.run_check(
             {

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -229,21 +229,13 @@ class CheckVersionsCase(unittest.TestCase):
         )
         self.assertEqual(code, 0)
 
-    def test_an_unquoted_numeric_version_is_rejected_with_quote_instructions(self):
-        # YAML reads version: 1.0 as a number; the scanner stays a scanner and
-        # rejects it rather than implementing YAML typing.
-        code, report = self.run_check(
-            {
-                "skills/sepia/SKILL.md": skill_md(
-                    ["name: sepia", "metadata:", "  version: 1.0"]
-                )
-            }
-        )
-        self.assertEqual(code, 1)
-        self.assertIn("quote it", report)
-
-    def test_unquoted_booleans_and_nulls_are_rejected_too(self):
-        for value in ("true", "null", "~", "off"):
+    def test_any_unquoted_version_is_rejected_with_quote_instructions(self):
+        # Inverted per review round five: enumerating what YAML reads as
+        # non-strings had no natural end (1.0, true, null, 0b10, ...), so an
+        # unquoted value is invalid, full stop. This includes 0.4.0, which
+        # YAML would read as a string: quoting is the requirement, not a
+        # workaround for particular scalar forms.
+        for value in ("1.0", "true", "null", "~", "off", "0b10", "0.4.0"):
             code, report = self.run_check(
                 {
                     "skills/sepia/SKILL.md": skill_md(
@@ -253,18 +245,6 @@ class CheckVersionsCase(unittest.TestCase):
             )
             self.assertEqual(code, 1, f"version: {value} should be rejected")
             self.assertIn("quote it", report)
-
-    def test_an_unquoted_dotted_version_is_a_plain_yaml_string_and_accepted(self):
-        # 0.4.0 is not a valid YAML number, so unquoted it is already a
-        # string; rejecting it would be a false red.
-        code, report = self.run_check(
-            {
-                "skills/sepia/SKILL.md": skill_md(
-                    ["name: sepia", "metadata:", "  version: 0.4.0"]
-                )
-            }
-        )
-        self.assertEqual(code, 0)
 
     def test_quoted_whitespace_in_frontmatter_is_held_to_the_json_rule(self):
         code, report = self.run_check(
@@ -277,12 +257,28 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("surrounding whitespace", report)
 
-    def test_flow_style_unquoted_number_is_rejected_too(self):
-        code, report = self.run_check(
-            {"skills/sepia/SKILL.md": skill_md(["name: sepia", "metadata: {version: 1.0}"])}
-        )
-        self.assertEqual(code, 1)
-        self.assertIn("quote it", report)
+    def test_flow_style_unquoted_values_are_rejected_too(self):
+        for value in ("1.0", "0.4.0"):
+            code, report = self.run_check(
+                {"skills/sepia/SKILL.md": skill_md(["name: sepia", f"metadata: {{version: {value}}}"])}
+            )
+            self.assertEqual(code, 1, f"flow version: {value} should be rejected")
+            self.assertIn("quote it", report)
+
+    def test_a_repository_under_a_skipped_ancestor_name_still_scans(self):
+        # Review round five: SKIP_DIRS applied to absolute path parts made a
+        # checkout at .../venv/<repo> skip every file and report all required
+        # manifests missing. Only directories below root may match.
+        nested = self.root / "venv" / "repo"
+        for rel, content in BASELINE.items():
+            path = nested / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, dict):
+                content = json.dumps(content, indent=2) + "\n"
+            path.write_text(content, encoding="utf-8")
+        code, report = check_versions.run(nested)
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
 
     # --- flow-style metadata ------------------------------------------------
 

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -183,6 +183,33 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("skills/sepia/SKILL.md: required", report)
 
+    def test_a_utf8_bom_before_the_frontmatter_is_tolerated(self):
+        # Editors on Windows add a BOM; real frontmatter loaders tolerate it.
+        # Exact-line delimiter matching must not turn an invisible byte into
+        # a red required check.
+        content = "\ufeff" + skill_md(["name: sepia", "metadata:", '  version: "0.4.0"'])
+        code, report = self.run_check({"skills/sepia/SKILL.md": content})
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
+
+    def test_a_corrupted_opening_delimiter_means_no_frontmatter(self):
+        # Review round 7: ---oops is not a frontmatter opener, but prefix
+        # matching accepted it, so the guard stayed green after the
+        # declaration was broken. A real YAML loader sees no frontmatter
+        # here; so must the scanner, and the required core then goes red.
+        content = "---oops\nname: sepia\nmetadata:\n  version: \"0.4.0\"\n---\n\n# sepia\n"
+        code, report = self.run_check({"skills/sepia/SKILL.md": content})
+        self.assertEqual(code, 1)
+        self.assertIn("skills/sepia/SKILL.md: required", report)
+
+    def test_a_corrupted_closing_delimiter_means_no_frontmatter(self):
+        # ---- is not a closing delimiter; without an exact --- line the
+        # block is unterminated and declares nothing.
+        content = "---\nname: sepia\nmetadata:\n  version: \"0.4.0\"\n----\n\n# sepia\n"
+        code, report = self.run_check({"skills/sepia/SKILL.md": content})
+        self.assertEqual(code, 1)
+        self.assertIn("skills/sepia/SKILL.md: required", report)
+
     def test_a_blank_line_inside_metadata_does_not_close_the_block(self):
         code, report = self.run_check(
             {

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -1,0 +1,208 @@
+"""Unit tests for scripts/check_versions.py.
+
+Each test builds a small repository in a temp directory and runs the whole
+check against it, asserting on the exit code and the report text. The cases
+mirror the ways the real repository could drift, including the two found in
+review: a required version field disappearing, and a version edited into a
+non-string value, both of which must fail rather than count as "not declared".
+
+Standard library only, like the script:  python3 -m unittest discover -s tests
+"""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import check_versions
+
+
+def skill_md(frontmatter_lines):
+    return "---\n" + "\n".join(frontmatter_lines) + "\n---\n\n# sepia\n"
+
+
+BASELINE = {
+    ".claude-plugin/plugin.json": {"name": "sepia", "version": "0.4.0"},
+    ".codex-plugin/plugin.json": {"name": "sepia", "version": "0.4.0"},
+    ".claude-plugin/marketplace.json": {"name": "sepia", "plugins": [{"name": "sepia"}]},
+    "plugin.json": {"name": "sepia"},
+    "skills/sepia/SKILL.md": skill_md(
+        ["name: sepia", "license: MIT", "metadata:", '  version: "0.4.0"']
+    ),
+}
+
+
+class CheckVersionsCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def write(self, files):
+        for rel, content in files.items():
+            path = self.root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(content, dict):
+                content = json.dumps(content, indent=2) + "\n"
+            path.write_text(content, encoding="utf-8")
+
+    def run_check(self, overrides=None):
+        files = dict(BASELINE)
+        files.update(overrides or {})
+        self.write(files)
+        return check_versions.run(self.root)
+
+    # --- the healthy repository ---------------------------------------------
+
+    def test_agreeing_declarations_pass(self):
+        code, report = self.run_check()
+        self.assertEqual(code, 0)
+        self.assertIn("3 declarations, all 0.4.0", report)
+
+    def test_undeclared_files_are_listed_not_failed(self):
+        code, report = self.run_check()
+        self.assertEqual(code, 0)
+        self.assertIn("plugin.json", report)
+        self.assertIn("(no version declared)", report)
+
+    # --- disagreement -------------------------------------------------------
+
+    def test_one_manifest_behind_fails_naming_both_versions(self):
+        code, report = self.run_check(
+            {".codex-plugin/plugin.json": {"name": "sepia", "version": "0.3.0"}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("0.3.0", report)
+        self.assertIn("0.4.0", report)
+
+    # --- the two review findings -------------------------------------------
+
+    def test_removing_a_required_version_field_fails(self):
+        # Review case: delete .codex-plugin/plugin.json's version. The two
+        # remaining declarations still agree, so without the required set this
+        # would pass, which is exactly the silent failure being guarded.
+        code, report = self.run_check(
+            {".codex-plugin/plugin.json": {"name": "sepia"}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("required to declare a version", report)
+        self.assertIn(".codex-plugin/plugin.json", report)
+
+    def test_a_non_string_version_fails_rather_than_counting_as_absent(self):
+        # Review case: "version": 0.5. Present-but-wrong is an error.
+        code, report = self.run_check(
+            {".codex-plugin/plugin.json": {"name": "sepia", "version": 0.5}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("not a non-empty string", report)
+
+    def test_an_empty_string_version_fails(self):
+        code, report = self.run_check(
+            {".codex-plugin/plugin.json": {"name": "sepia", "version": ""}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("not a non-empty string", report)
+
+    # --- frontmatter scoping ------------------------------------------------
+
+    def test_version_under_another_key_is_not_the_skill_version(self):
+        # Review case: compatibility.version must not shadow metadata.version.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    [
+                        "name: sepia",
+                        "compatibility:",
+                        '  version: "9.9.9"',
+                        "metadata:",
+                        '  version: "0.4.0"',
+                    ]
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("9.9.9", report)
+
+    def test_only_a_foreign_version_means_the_skill_declares_none(self):
+        # With no metadata.version at all, the skill declares nothing, and
+        # since it is a required file that is a failure.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "compatibility:", '  version: "9.9.9"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("skills/sepia/SKILL.md: required", report)
+
+    def test_a_top_level_frontmatter_version_does_not_count(self):
+        # The Agent Skills shape puts the version under metadata; a top-level
+        # version key belongs to nothing and must not be picked up.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ['version: "9.9.9"', "name: sepia", "metadata:", '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("9.9.9", report)
+
+    def test_an_empty_metadata_version_fails(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", "  version:"]
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("present but empty", report)
+
+    # --- discovery of manifests that grow a version later -------------------
+
+    def test_root_plugin_json_growing_a_matching_version_is_counted(self):
+        code, report = self.run_check(
+            {"plugin.json": {"name": "sepia", "version": "0.4.0"}}
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("4 declarations", report)
+
+    def test_root_plugin_json_growing_a_different_version_fails(self):
+        code, report = self.run_check(
+            {"plugin.json": {"name": "sepia", "version": "0.5.0"}}
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("0.5.0", report)
+
+    def test_a_marketplace_plugins_entry_version_is_checked_by_label(self):
+        code, report = self.run_check(
+            {
+                ".claude-plugin/marketplace.json": {
+                    "name": "sepia",
+                    "plugins": [{"name": "sepia", "version": "0.9.9"}],
+                }
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("plugins[0]", report)
+        self.assertIn("0.9.9", report)
+
+    # --- the guard guarding itself ------------------------------------------
+
+    def test_an_empty_tree_fails_rather_than_passing_vacuously(self):
+        self.write({})  # nothing at all
+        code, report = check_versions.run(self.root)
+        self.assertEqual(code, 1)
+
+    def test_unreadable_json_fails(self):
+        code, report = self.run_check({".codex-plugin/plugin.json": "{not json"})
+        self.assertEqual(code, 1)
+        self.assertIn("unreadable", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follows #21. Thank you for the two implementation notes; both shaped the design rather than being bolted on.

## What it does

`scripts/check_versions.py` reads every file that declares a version and fails if they disagree. `.github/workflows/version-consistency.yml` runs it on push and pull request.

Current output on `main`:

```
  .claude-plugin/plugin.json        0.4.0
  .codex-plugin/plugin.json         0.4.0
  skills/sepia/SKILL.md             0.4.0
  .agents/plugins/marketplace.json  (no version declared)
  .claude-plugin/marketplace.json   (no version declared)
  plugin.json                       (no version declared)
  skills/sepia-recreate/SKILL.md    (no version declared)
  skills/sepia-refactor/SKILL.md    (no version declared)
  skills/sepia-review/SKILL.md      (no version declared)
  skills/sepia-write/SKILL.md       (no version declared)

version check: OK, 3 declarations, all 0.4.0.
```

## On your first note: discovery, not pinned paths

Nothing is hardcoded to a path. Any file named `plugin.json` or `marketplace.json` is read wherever it sits, and every `SKILL.md`'s frontmatter is read for `metadata.version`. Both JSON shapes are covered: a top-level `version`, and a `version` on each entry of a `plugins` array, which is where a marketplace file would put one.

So the root `plugin.json` from #14 is already in scope. It declares no version today, which is a legitimate state and is listed rather than failed. If it gains one later it is checked from that moment, with nobody needing to remember this file exists. Same for either `marketplace.json`, and for the four wrapper skills.

Printing the files that declare nothing is deliberate: it is how a maintainer sees what the scan actually reached, so a manifest that discovery started missing would show up as an absence in that list rather than as silence.

One more case, since it is the way a checker like this usually rots: **discovery finding nothing is a failure, not a pass.** If the layout moves and this script stops matching anything, it says so instead of going green.

## On your second note: no new dependencies

Standard library only. The frontmatter is parsed with a line scan rather than PyYAML, and the workflow calls `python3` directly rather than running a setup action, so nothing is installed and no lockfile appears. Verified on Python 3.9.6 as well as 3.12.

## Verification

Each case run against a copy of this repository, exit status checked:

| Case | Result |
|---|---|
| `main` as it stands | 3 declarations, all `0.4.0`, exit 0 |
| `.codex-plugin/plugin.json` set to `0.3.0` | `FAILED, 2 different versions declared: 0.3.0, 0.4.0`, exit 1 |
| **root `plugin.json` given `0.5.0`** | `FAILED, 2 different versions declared: 0.4.0, 0.5.0`, exit 1 |
| root `plugin.json` given a matching `0.4.0` | passes, now 4 declarations |
| a version added to `marketplace.json`'s `plugins[0]` | reported as `.claude-plugin/marketplace.json → plugins[0]  0.9.9` |
| run against a tree with no manifests at all | fails rather than passing vacuously |

The third row is your fourth-manifest case, and the fourth row is the same file behaving correctly once it agrees.

## What this does not do

It compares declared versions to each other, not to a release, a tag, or a CHANGELOG. Those live outside the working tree and a repository check cannot see them. Worth naming, because a guard's real coverage is whatever it can observe, which is not the same as the checklist it came from.

Happy to adjust naming, output format, or the workflow triggers to taste.