### PR TITLE
feat: behavioral eval suite run by claude plugin eval in CI

### DIFF
--- a/.github/workflows/behavioral-eval.yml
+++ b/.github/workflows/behavioral-eval.yml
@@ -1,0 +1,55 @@
+name: behavioral eval
+
+# Runs `claude plugin eval` against the plugin's evals/ suite: each case is a
+# prompt run in an isolated session with only this plugin loaded, scored by its
+# graders, plus a no-plugin baseline arm for the score delta.
+#
+# Push-to-main only (plus manual dispatch): the run spends the maintainer's
+# Claude subscription quota via CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token`),
+# so it must never trigger on fork PRs. CLAUDE_CODE_WALNUT_SPIRE enables the
+# early-access `plugin eval` command on machines that cannot receive the
+# per-organization rollout — CI runners are its documented audience.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - skills/**
+      - evals/**
+      - plugin.json
+      - .claude-plugin/**
+      - .github/workflows/behavioral-eval.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_WALNUT_SPIRE: "1"
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: install claude code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: run behavioral eval
+        # --model pinned so a model rollout does not read as a plugin
+        # regression; judge stays the default (haiku). Threshold 0.7 tolerates
+        # one noisy judge vote without letting a broken skill pass.
+        run: |
+          claude plugin eval . --json results.json --threshold 0.7 \
+            --model claude-sonnet-5 --no-publish
+      - name: summarize
+        if: always()
+        run: |
+          [ -f results.json ] || { echo "no results.json produced"; exit 0; }
+          jq -r '.cases[] | .name as $c | .arms | to_entries[] |
+            "\($c) [\(.key)] score=" +
+            ((([.value[].score] | add / length * 100 | round) / 100) | tostring)' results.json
+          jq -r '.cases[].arms.with[].graders[] |
+            "  \(.name): passed=\(.passed) scored=\(.scored // true)"' results.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+evals/results/

--- a/evals/deaify-release-note/graders/no-slop-markers.md
+++ b/evals/deaify-release-note/graders/no-slop-markers.md
@@ -1,0 +1,7 @@
+---
+type: regex
+target: last_message
+pattern: "thrilled|seamless|robust|blazing|empowering|unwavering|testament|delve|north star|reimagining|isn't just|not just an?|like never before|speed of thought"
+flags: i
+match: not_contains
+---

--- a/evals/deaify-release-note/graders/reads-human.md
+++ b/evals/deaify-release-note/graders/reads-human.md
@@ -1,0 +1,13 @@
+---
+type: llm
+focus: last_message
+---
+
+The response is a rewritten release note. Judge only the rewritten text. Reordering, headings, bullet lists, and small connective phrases are all acceptable.
+
+PASS requires both:
+
+1. These facts all survive in some form: the product is Fathom v2.4; dark mode; exports about 40% faster per benchmarks; SSO (for teams / team onboarding); CSV imports no longer silently drop rows containing quoted commas.
+2. None of these AI-marketing patterns appear: stock promotional adjectives ("thrilled", "seamless", "robust", "blazing", "unwavering", "game-changing"); "not just X, it's Y" contrast framing; a closing sentence about commitment, excellence, or "we can't wait"; a triadic crescendo list like "faster, smarter, and more intuitive"; exclamation marks.
+
+FAIL only if a fact from point 1 is missing or contradicted, or a pattern from point 2 appears.

--- a/evals/deaify-release-note/graders/skill-fired.md
+++ b/evals/deaify-release-note/graders/skill-fired.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+input_match: '"skill"\s*:\s*"(?:[\w-]+:)?sepia(?:-[\w-]+)?"'
+min: 1
+---

--- a/evals/deaify-release-note/prompt.md
+++ b/evals/deaify-release-note/prompt.md
@@ -1,0 +1,12 @@
+---
+name: deaify-release-note
+description: Core behavior - strip AI flavor from a release note while keeping every fact
+tags: [behavior, professional]
+max_turns: 16
+timeout_seconds: 600
+allowed_tools: [Read, Glob, Grep, Skill]
+---
+
+This release note reads AI-generated. Strip the AI flavor but keep every fact. Reply with only the rewritten note, nothing else.
+
+We're thrilled to announce Fathom v2.4 — and this isn't just an update, it's a fundamental reimagining of how you work with your data. We've delved deep into your feedback to deliver an experience that's faster, smarter, and more intuitive. Dark mode is finally here, bringing a seamless, eye-friendly aesthetic to every corner of the app. Exports are now a blazing 40% faster in our benchmarks, empowering you to move at the speed of thought. For teams, we've introduced robust SSO support, streamlining onboarding like never before. We've also resolved an issue where CSV imports could silently drop rows containing quoted commas — your data integrity is our north star. This release is a testament to our unwavering commitment to excellence, and we can't wait to see what you build with it!


### PR DESCRIPTION
## What

The first behavioral validation for sepia — the answer to "怎麼驗證 skill 有符合行為（去 AI 味）". Until now the repo only had structural checks (version consistency); nothing proved the skill's actual effect on text.

- `evals/deaify-release-note/` — one `claude plugin eval` case: a release note dense with slop fingerprints and four checkable facts, with a natural "strip the AI flavor" prompt that routes through the skill's description (never naming it).
- Three graders: `tool_used: Skill` plugin-fired indicator (unscored under ablation), a free deterministic regex banning verbatim slop markers, and an LLM rubric (2-of-3 votes) requiring facts to survive and marketing patterns to be gone.
- `.github/workflows/behavioral-eval.yml` — push-to-main + manual dispatch only. Never `pull_request`: the run spends the maintainer's subscription quota and executes repo content, so fork PRs must not trigger it.

## Verification

Local pilot (`claude plugin eval . --runs 1`, with-without ablation): with-arm **1.00**, baseline **1.00**, Δ 0.00, skill fired 1×, exit 0. Δ=0 is expected on this case — baseline Claude also handles short marketing slop; this case gates "fires on natural phrasing, doesn't degrade output". A fiction case targeting StoryScope narrative features (where baseline should lag) is the natural follow-up.

## Before merging

Set the repo secret or the workflow's first main run fails on auth:

```
claude setup-token   # local, browser OAuth
gh secret set CLAUDE_CODE_OAUTH_TOKEN -R Nanako0129/sepia
```

`CLAUDE_CODE_WALNUT_SPIRE=1` in the workflow enables the early-access `plugin eval` command; CI runners are the documented audience for that variable (they can't receive the per-org server-side rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U76eiqsrkmHSxZFiXhiG8F