### PR TITLE
fix(ci): materialize a credentials file so the eval sandbox child can authenticate

### DIFF
--- a/.github/workflows/behavioral-eval.yml
+++ b/.github/workflows/behavioral-eval.yml
@@ -37,6 +37,22 @@ jobs:
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: materialize claude.ai credentials
+        # The eval sandbox authenticates each run's child by copying the
+        # parent's credentials file (~/.claude/.credentials.json on Linux)
+        # into the run's fresh config dir. CLAUDE_CODE_OAUTH_TOKEN is not on
+        # the sandbox's env pass-through list (only ANTHROPIC_API_KEY-style
+        # env auth is), so on a runner that never ran `claude login` the
+        # child was rejected at the first run (partialReason auth_failed,
+        # observed twice). Write the file a real login would have left,
+        # from the same token. expiresAt is only metadata here — the
+        # setup-token itself carries the real expiry.
+        run: |
+          umask 077
+          mkdir -p "$HOME/.claude"
+          EXPIRES=$(( ($(date +%s) + 250*24*3600) * 1000 ))
+          printf '{"claudeAiOauth":{"accessToken":"%s","refreshToken":"","expiresAt":%s,"scopes":["user:inference"]}}' \
+            "$CLAUDE_CODE_OAUTH_TOKEN" "$EXPIRES" > "$HOME/.claude/.credentials.json"
       - name: run behavioral eval
         # --model pinned so a model rollout does not read as a plugin
         # regression; judge stays the default (haiku). Threshold 0.7 tolerates
@@ -48,6 +64,9 @@ jobs:
         if: always()
         run: |
           [ -f results.json ] || { echo "no results.json produced"; exit 0; }
+          jq -r '"partial=\(.partial // false) reason=\(.partialReason // "none")"' results.json
+          jq -r '.cases[].arms | to_entries[] | .key as $a | .value[] |
+            select(.error != null) | "  [\($a)] run error: \(.error)"' results.json
           jq -r '.cases[] | .name as $c | .arms | to_entries[] |
             "\($c) [\(.key)] score=" +
             ((([.value[].score] | add / length * 100 | round) / 100) | tostring)' results.json


### PR DESCRIPTION
## What

Two dispatched runs of `behavioral eval` failed in ~3s with exit 2 (`auth_failed`). The harness authenticates each sandboxed child by **copying the parent's claude.ai credentials file** into the run's fresh config dir; `CLAUDE_CODE_OAUTH_TOKEN` is not on the sandbox's env pass-through list (only the `ANTHROPIC_API_KEY` family is). A CI runner has no credentials file, so every child run was rejected — the second failure after a cleanly re-uploaded secret rules out a mangled secret value.

Fix: write `~/.claude/.credentials.json` (the exact file `claude login` leaves on Linux, CLI's own `claudeAiOauth` schema, `umask 077`) from the same secret before running the eval. Same token, same subscription billing — just presented where the sandbox actually looks.

Also: the summarize step now prints `partial`/`partialReason` and per-run `error`, so the next failure names itself in the job log.

## Verification

Schema and copy mechanism read from the harness's own sandbox reference and the CLI's credential store code; the fix is observable only on a real runner — dispatch `behavioral eval` after merge, expected: with 1.00 / without 1.00 / exit 0 (local pilot already produced exactly that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U76eiqsrkmHSxZFiXhiG8F