### PR TITLE
fix: prune skipped directories during the walk, not after it

### DIFF
--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -37,6 +37,7 @@ Exit status is 0 when every declaration agrees and the required files all
 declare, 1 otherwise. The unit tests live in tests/test_check_versions.py.
 """
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -62,15 +63,20 @@ REQUIRED = (
 
 
 def _iter_files(root):
-    for path in sorted(root.rglob("*")):
-        if not path.is_file():
-            continue
-        # Only the directories BELOW root count: a repository checked out at
-        # /work/venv/sepia must not have every file skipped because an
-        # ancestor happens to be named venv (review round 5).
-        if any(part in SKIP_DIRS for part in path.relative_to(root).parts[:-1]):
-            continue
-        yield path
+    """Walk root, pruning skipped directories instead of filtering afterwards.
+
+    rglob enumerated every descendant, including a full node_modules or
+    .venv, and only then discarded them, so the skip list prevented parsing
+    but not the traversal cost (review round 7). os.walk prunes in place.
+    Walking from root also means only directories BELOW root can match: a
+    repository checked out at /work/venv/sepia is unaffected by its ancestor
+    name (review round 5). Both listings are sorted so the report order is
+    stable across platforms.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        for name in sorted(filenames):
+            yield Path(dirpath) / name
 
 
 def _valid(value):

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -284,6 +284,16 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("surrounding whitespace", report)
 
+    def test_manifests_inside_skipped_directories_are_not_scanned(self):
+        # A vendored manifest deep in node_modules must not fail the check;
+        # the walk prunes these directories instead of reading and then
+        # discarding them.
+        code, report = self.run_check(
+            {"node_modules/dep/.claude-plugin/plugin.json": {"name": "dep", "version": "9.9.9"}}
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("9.9.9", report)
+
     def test_a_repository_under_a_skipped_ancestor_name_still_scans(self):
         # Review round five: SKIP_DIRS applied to absolute path parts made a
         # checkout at .../venv/<repo> skip every file and report all required


### PR DESCRIPTION
Closes #36.

## Summary

- `_iter_files` now walks with `os.walk` and prunes `SKIP_DIRS` from `dirnames` in place, instead of `rglob("*")` enumerating every descendant (and `sorted()` materializing the list) before filtering. A skipped directory is never entered, so a local checkout carrying a full `node_modules` or `.venv` no longer pays the walk. Correctness is unaffected, exactly as the issue notes; this is traversal cost only.
- This is the right layer because the cost lived in the traversal itself, not in what was done with the results. One structural bonus: walking from `root` means only directories below `root` can match, so the round-five `relative_to` guard is absorbed by the same mechanism and its special case disappears.
- Both directory and file listings are sorted so the report order stays stable across platforms.

## Verification

- `python3 -m unittest discover -s tests` → `Ran 29 tests ... OK` on Python 3.12.13 and 3.9.6 (one behavioral test added: a manifest declaring `9.9.9` planted inside `node_modules` does not reach the check)
- `python3 scripts/check_versions.py` on this repository → `version check: OK, 3 declarations, all 0.4.0.`
- Planted a `node_modules` tree of 3,000 files next to one real manifest: `_iter_files` visits 1 path, ~0.1 ms; before the change it enumerated all 3,001 before discarding
- Verified against current `main` (post-#22 merge plus the eval workflow): clean merge, same green suite
- Not run: nothing else applies; no network, no new dependencies, standard library only as before