### PR TITLE
fix: duplicate metadata.version keys are invalid, not first-wins

### DIFF
--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -144,7 +144,10 @@ def read_frontmatter_version(path, rel):
     `metadata:` counts. Inline metadata (flow mappings, scalars) is refused
     with instructions to use block style: two review rounds of quoted-span and
     nested-brace edge cases traced back to hand-parsing flow, and the refusal
-    is loud and names its own fix. A line scan rather than a YAML parser, carrying two pieces of
+    is loud and names its own fix. Declaring version more than once is an
+    error, not a first-wins pick: duplicate-tolerant YAML parsers commonly
+    keep the last value, so picking the first can pass on a stale one
+    (issue #39). A line scan rather than a YAML parser, carrying two pieces of
     state: entering the frontmatter's `metadata:` key opens the block and the
     next top-level key closes it, and the block's first child fixes the
     indentation that direct children must sit at. Anything deeper belongs to a
@@ -177,6 +180,7 @@ def read_frontmatter_version(path, rel):
 
     in_metadata = False
     child_indent = None
+    declared = []
     for line in lines[1:close]:
         if not line.strip():
             continue
@@ -213,7 +217,18 @@ def read_frontmatter_version(path, rel):
             continue
         stripped = line.strip()
         if stripped.startswith("version:"):
-            return _frontmatter_scalar(stripped[len("version:"):], rel)
+            declared.append(stripped[len("version:"):])
+    if len(declared) > 1:
+        # Returning on the first key would keep a stale value alive: YAML
+        # parsers that tolerate duplicate mapping keys commonly retain the
+        # LAST one, so first-wins can agree with the manifests while the
+        # effective version differs. Present-but-wrong, so it is an error,
+        # never a pick (issue #39).
+        return None, [(rel,
+            f"metadata declares version {len(declared)} times; duplicate "
+            "keys are invalid, keep exactly one")]
+    if declared:
+        return _frontmatter_scalar(declared[0], rel)
     return None, []
 
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -69,6 +69,13 @@ REQUIRED = (
 # but the restriction is smaller and keeps the scanner a scanner.
 ALT_VERSION_KEY_RE = re.compile(r"""^(?:(["'])version\1|version\s)\s*:""")
 
+# The same rule one level up: a top-level key that YAML would read as
+# `metadata` under a spelling other than exactly `metadata:`. Psych resolves
+# a quoted "metadata": to the same key and keeps that block's value, while
+# the equality check here read it as a different key and closed the block,
+# so only the first exact-spelling block was counted (review on PR #41).
+ALT_METADATA_KEY_RE = re.compile(r"""^(?:(["'])metadata\1|metadata\s)\s*:""")
+
 
 def _iter_files(root):
     for path in sorted(root.rglob("*")):
@@ -199,6 +206,12 @@ def read_frontmatter_version(path, rel):
             # top-level key that closes the block (review round 4).
             continue
         if not line[:1].isspace():
+            if ALT_METADATA_KEY_RE.match(line):
+                key = line.split(":", 1)[0].rstrip()
+                return None, [(rel,
+                    f"a metadata key must be spelled exactly 'metadata:'; "
+                    f"found {key!r}, which YAML reads as the same key and "
+                    "which slips past the duplicate guard, rewrite it")]
             head, sep, rest = line.partition(":")
             if head.strip() == "metadata" and sep:
                 rest = rest.split(" #")[0].strip()

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -60,6 +60,15 @@ REQUIRED = (
     "skills/sepia/SKILL.md",
 )
 
+# A direct-child key that a YAML parser would resolve to `version` under a
+# spelling other than exactly `version:` — a quoted key, or whitespace before
+# the colon. Ruby Psych reads these as the same key and keeps the last value,
+# so an alternate spelling slips past the duplicate guard: one stale exact key
+# plus one alternate-spelled new value reads as a single, stale declaration.
+# Per review the spelling is restricted rather than parsed: the set is closed,
+# but the restriction is smaller and keeps the scanner a scanner.
+ALT_VERSION_KEY_RE = re.compile(r"""^(?:(["'])version\1|version\s)\s*:""")
+
 
 def _iter_files(root):
     for path in sorted(root.rglob("*")):
@@ -218,6 +227,12 @@ def read_frontmatter_version(path, rel):
         stripped = line.strip()
         if stripped.startswith("version:"):
             declared.append(stripped[len("version:"):])
+        elif ALT_VERSION_KEY_RE.match(stripped):
+            key = stripped.split(":", 1)[0].rstrip()
+            return None, [(rel,
+                f"a version key must be spelled exactly 'version:'; found "
+                f"{key!r}, which YAML reads as the same key and which slips "
+                "past the duplicate guard, rewrite it")]
     if len(declared) > 1:
         # Returning on the first key would keep a stale value alive: YAML
         # parsers that tolerate duplicate mapping keys commonly retain the

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -208,6 +208,44 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("declares version 2 times", report)
 
+    def test_alternate_spellings_of_the_version_key_are_invalid(self):
+        # Review on PR #41: "version": / 'version': / version : resolve to the
+        # same key in YAML (Psych keeps the last value), so an alternate
+        # spelling slipped past the duplicate counter, one stale exact key
+        # plus one alternate-spelled new value read as a single declaration.
+        # Spelling is restricted rather than parsed.
+        for line in ('"version": "9.9.9"', "'version': \"9.9.9\"", 'version : "9.9.9"'):
+            code, report = self.run_check(
+                {
+                    "skills/sepia/SKILL.md": skill_md(
+                        ["name: sepia", "metadata:", '  version: "0.4.0"', f"  {line}"]
+                    )
+                }
+            )
+            self.assertEqual(code, 1, f"{line} should be invalid")
+            self.assertIn("spelled exactly", report)
+
+    def test_an_alternate_spelling_alone_is_also_invalid(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  "version": "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("spelled exactly", report)
+
+    def test_other_quoted_keys_at_child_level_are_not_flagged(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  "author": "x"', '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+
     def test_two_metadata_blocks_each_declaring_a_version_are_invalid(self):
         # A duplicated metadata key with a version in each block is the same
         # ambiguity one level up; the count spans the whole frontmatter.

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -183,6 +183,45 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("skills/sepia/SKILL.md: required", report)
 
+    def test_duplicate_version_keys_are_invalid_not_first_wins(self):
+        # Issue #39: with a stale first key matching the manifests, first-wins
+        # passed while a duplicate-tolerant YAML parser would take the LAST
+        # value. Duplicates are an error, never a pick.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  version: "0.4.0"', '  version: "9.9.9"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("declares version 2 times", report)
+
+    def test_duplicate_version_keys_with_equal_values_are_still_invalid(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  version: "0.4.0"', '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("declares version 2 times", report)
+
+    def test_two_metadata_blocks_each_declaring_a_version_are_invalid(self):
+        # A duplicated metadata key with a version in each block is the same
+        # ambiguity one level up; the count spans the whole frontmatter.
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", "metadata:", '  version: "0.4.0"',
+                     "license: MIT", "metadata:", '  version: "9.9.9"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("declares version 2 times", report)
+
     def test_a_utf8_bom_before_the_frontmatter_is_tolerated(self):
         # Editors on Windows add a BOM; real frontmatter loaders tolerate it.
         # Exact-line delimiter matching must not turn an invisible byte into

--- a/tests/test_check_versions.py
+++ b/tests/test_check_versions.py
@@ -208,6 +208,44 @@ class CheckVersionsCase(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("declares version 2 times", report)
 
+    def test_alternate_spellings_of_the_metadata_key_are_invalid(self):
+        # Same rule one level up (review on PR #41): "metadata": resolves to
+        # the same key in YAML, but the equality check read it as a different
+        # key and closed the block, so a stale exact-spelling block passed
+        # while the quoted block held the effective newer version.
+        for opener in ('"metadata":', "'metadata':", 'metadata :'):
+            code, report = self.run_check(
+                {
+                    "skills/sepia/SKILL.md": skill_md(
+                        ["name: sepia", "metadata:", '  version: "0.4.0"',
+                         opener, '  version: "9.9.9"']
+                    )
+                }
+            )
+            self.assertEqual(code, 1, f"{opener} should be invalid")
+            self.assertIn("spelled exactly 'metadata:'", report)
+
+    def test_a_lone_alternate_metadata_spelling_is_also_invalid(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ["name: sepia", '"metadata":', '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("spelled exactly 'metadata:'", report)
+
+    def test_other_quoted_top_level_keys_are_not_flagged(self):
+        code, report = self.run_check(
+            {
+                "skills/sepia/SKILL.md": skill_md(
+                    ['"author": x', "name: sepia", "metadata:", '  version: "0.4.0"']
+                )
+            }
+        )
+        self.assertEqual(code, 0)
+
     def test_alternate_spellings_of_the_version_key_are_invalid(self):
         # Review on PR #41: "version": / 'version': / version : resolve to the
         # same key in YAML (Psych keeps the last value), so an alternate


### PR DESCRIPTION
Closes #39.

## Summary

- The frontmatter scan returned on the first direct-child `version:` key. With a stale first value agreeing with the JSON manifests, the check passed while a duplicate-tolerant YAML parser would take the **last** value and the effective version differed. Per the issue's direction and the script's own present-but-wrong rule, a duplicate is an explicit invalid, never a pick: `metadata declares version N times; duplicate keys are invalid, keep exactly one`.
- Right layer: the count is taken across the whole frontmatter, so a duplicated `metadata:` block with a version in each fails the same way — the same ambiguity one level up, caught by the same counter rather than a second rule.

## Verification

- `python3 -m unittest discover -s tests` → `Ran 31 tests ... OK` on Python 3.12.13 and 3.9.6
- Three new tests: the stale-first false-green shape itself (`"0.4.0"` then `"9.9.9"`), equal values still counting as a duplicate, and the double-`metadata:`-block case
- `python3 scripts/check_versions.py` on this repository → `version check: OK, 3 declarations, all 0.4.0.`
- Branch cut from current `main`; single commit; standard library only as before
- Not run: nothing else applies; no network, no new dependencies