### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sepia",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
   "author": {
     "name": "Nanako Tsai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sepia",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
   "skills": "./skills/",
   "license": "MIT",

--- a/skills/sepia/SKILL.md
+++ b/skills/sepia/SKILL.md
@@ -3,7 +3,7 @@ name: sepia
 description: Make AI-generated writing read as human-written, in fiction and in professional prose. Repairs the narrative architecture of fiction and stories (based on StoryScope, arXiv:2604.03136); routes professional text through domain rules for release notes, announcements, PR and issue replies, code-review comments, incident postmortems, tickets, work orders, technical articles, and blog posts. Four operations - write, review (diagnose AI tells without editing), refactor (minimal in-place edits), recreate (full rewrite). Use when asked to humanize, de-AI, unslop, or strip AI flavor from any text; when writing or revising any of these document types; or whenever output must not read as machine-written.
 license: MIT
 metadata:
-  version: "0.4.0"
+  version: "0.4.1"
 ---
 
 # Sepia — de-AI writing


### PR DESCRIPTION
Bumps the three version declarations (SKILL.md frontmatter, both plugin manifests) to 0.4.1 for the release. `check_versions.py` reports all three agree; suite green (41 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwGKATJ6u4rgWyLsbg4Grj