### PR TITLE
chore: add Patreon sponsorship (FUNDING.yml and README Support sections)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: Nanako0129

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ sepia/
 
 Full digests with links in [`research/`](research/). Primary: StoryScope ([arXiv:2604.03136](https://arxiv.org/abs/2604.03136)); LAMP ([CHI 2025](https://arxiv.org/abs/2409.14509)); Measuring AI Slop ([arXiv:2509.19163](https://arxiv.org/abs/2509.19163)); Reinhart et al. ([PNAS 2025](https://arxiv.org/abs/2410.16107)); Russell et al. ([ACL 2025](https://arxiv.org/abs/2501.15654)); NarraBench ([arXiv:2510.09869](https://arxiv.org/abs/2510.09869)); Echoes in AI ([PNAS 2025](https://arxiv.org/abs/2501.00273)); QUDsim ([COLM 2025](https://arxiv.org/abs/2504.09373)); Beguš ([2024](https://arxiv.org/abs/2310.12902)); Beyond Checkmate ([EMNLP 2025](https://arxiv.org/abs/2501.19301)); Nonaka & Perry ([2025](https://arxiv.org/abs/2510.18932)); Chakrabarty et al. ([2026](https://arxiv.org/abs/2510.13939)).
 
+## Support
+
+sepia is free, needs no account, and ships the research behind every rule. Keeping it honest is the expensive part: each release is checked with live model runs on several platforms, the behavioral eval spends model tokens on every push to main, and the evidence ledger grows only by reading the papers, not their summaries. Sponsorship covers those model and CI costs and the maintainer time. If sepia has made something you wrote read better, you can support it on Patreon.
+
+[![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Full digests with links in [`research/`](research/). Primary: StoryScope ([arXiv
 
 ## Support
 
-sepia is free, needs no account, and ships the research behind every rule. What costs money is the evidence: the literature surveys are delegated to research agents that spend model quota reading papers in primary form, and every rule change is tested with live model runs (A/B stories, end-to-end reviews across platforms) before it ships. Sponsorship covers that model quota and the maintainer time. If sepia has made something you wrote read better, you can support it on Patreon.
+You can use sepia for free without an account. The research behind every rule is open. Ongoing costs are just maintainer time and two kinds of model quota: delegating literature surveys to research agents that read primary papers, and running live models to test rule changes on A/B stories and cross-platform end-to-end reviews before shipping. You can support the project on Patreon.
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Full digests with links in [`research/`](research/). Primary: StoryScope ([arXiv
 
 ## Support
 
-sepia is free, needs no account, and ships the research behind every rule. Keeping it honest is the expensive part: each release is checked with live model runs on several platforms, the behavioral eval spends model tokens on every push to main, and the evidence ledger grows only by reading the papers, not their summaries. Sponsorship covers those model and CI costs and the maintainer time. If sepia has made something you wrote read better, you can support it on Patreon.
+sepia is free, needs no account, and ships the research behind every rule. What costs money is the evidence: the literature surveys are delegated to research agents that spend model quota reading papers in primary form, and every rule change is tested with live model runs (A/B stories, end-to-end reviews across platforms) before it ships. Sponsorship covers that model quota and the maintainer time. If sepia has made something you wrote read better, you can support it on Patreon.
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,7 +177,7 @@ sepia/
 
 ## 赞助
 
-sepia 免费、无需账号，每条规则背后的研究都一并公开。花钱的是证据本身：文献调查委派给研究 agent，它们阅读论文原文会消耗模型额度；每条规则改动上线前，都用真实模型实测（A/B 对照小说、跨平台的端到端审查）。赞助用于支付这些模型额度，以及维护时间。如果 sepia 让你写的东西读起来更好，欢迎在 Patreon 上支持。
+sepia 任何人都能免费用，也不需要注册账号。每条规则背后的研究全部公开。项目的实际开销只有维护时间与两种模型额度：委派研究 agent 读论文原文做文献调查，以及规则改动上线前用真实模型实测 A/B 对照小说和跨平台端到端审查。欢迎在 Patreon 上支持这个项目。
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,7 +177,7 @@ sepia/
 
 ## 赞助
 
-sepia 免费、无需账号，每条规则背后的研究都一并公开。花钱的是把它做得可信这件事：每次发版都在多个平台上用真实模型跑验证，行为测试每次推送到 main 都会消耗模型 token，证据清单只靠阅读论文原文增长，不靠摘要。赞助用于支付这些模型与 CI 费用，以及维护时间。如果 sepia 让你写的东西读起来更好，欢迎在 Patreon 上支持。
+sepia 免费、无需账号，每条规则背后的研究都一并公开。花钱的是证据本身：文献调查委派给研究 agent，它们阅读论文原文会消耗模型额度；每条规则改动上线前，都用真实模型实测（A/B 对照小说、跨平台的端到端审查）。赞助用于支付这些模型额度，以及维护时间。如果 sepia 让你写的东西读起来更好，欢迎在 Patreon 上支持。
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,6 +175,12 @@ sepia/
 
 完整摘要与链接见 [`research/`](research/)。主要来源：StoryScope ([arXiv:2604.03136](https://arxiv.org/abs/2604.03136)); LAMP ([CHI 2025](https://arxiv.org/abs/2409.14509)); Measuring AI Slop ([arXiv:2509.19163](https://arxiv.org/abs/2509.19163)); Reinhart et al. ([PNAS 2025](https://arxiv.org/abs/2410.16107)); Russell et al. ([ACL 2025](https://arxiv.org/abs/2501.15654)); NarraBench ([arXiv:2510.09869](https://arxiv.org/abs/2510.09869)); Echoes in AI ([PNAS 2025](https://arxiv.org/abs/2501.00273)); QUDsim ([COLM 2025](https://arxiv.org/abs/2504.09373)); Beguš ([2024](https://arxiv.org/abs/2310.12902)); Beyond Checkmate ([EMNLP 2025](https://arxiv.org/abs/2501.19301)); Nonaka & Perry ([2025](https://arxiv.org/abs/2510.18932)); Chakrabarty et al. ([2026](https://arxiv.org/abs/2510.13939)).
 
+## 赞助
+
+sepia 免费、无需账号，每条规则背后的研究都一并公开。花钱的是把它做得可信这件事：每次发版都在多个平台上用真实模型跑验证，行为测试每次推送到 main 都会消耗模型 token，证据清单只靠阅读论文原文增长，不靠摘要。赞助用于支付这些模型与 CI 费用，以及维护时间。如果 sepia 让你写的东西读起来更好，欢迎在 Patreon 上支持。
+
+[![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
+
 ## 许可证
 
 MIT

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -175,6 +175,12 @@ sepia/
 
 完整摘要與連結見 [`research/`](research/)。主要來源：StoryScope ([arXiv:2604.03136](https://arxiv.org/abs/2604.03136)); LAMP ([CHI 2025](https://arxiv.org/abs/2409.14509)); Measuring AI Slop ([arXiv:2509.19163](https://arxiv.org/abs/2509.19163)); Reinhart et al. ([PNAS 2025](https://arxiv.org/abs/2410.16107)); Russell et al. ([ACL 2025](https://arxiv.org/abs/2501.15654)); NarraBench ([arXiv:2510.09869](https://arxiv.org/abs/2510.09869)); Echoes in AI ([PNAS 2025](https://arxiv.org/abs/2501.00273)); QUDsim ([COLM 2025](https://arxiv.org/abs/2504.09373)); Beguš ([2024](https://arxiv.org/abs/2310.12902)); Beyond Checkmate ([EMNLP 2025](https://arxiv.org/abs/2501.19301)); Nonaka & Perry ([2025](https://arxiv.org/abs/2510.18932)); Chakrabarty et al. ([2026](https://arxiv.org/abs/2510.13939)).
 
+## 贊助
+
+sepia 免費、不用帳號，每條規則背後的研究都一起公開。花錢的是把它做得可信這件事：每次發版都在多個平台上用真實模型跑驗證，行為測試每次推上 main 都會消耗模型 token，證據清單只靠讀論文原文增長，不靠摘要。贊助用來支付這些模型與 CI 費用，以及維護時間。如果 sepia 讓你寫的東西讀起來更好，歡迎在 Patreon 上支持。
+
+[![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
+
 ## 授權
 
 MIT

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -177,7 +177,7 @@ sepia/
 
 ## 贊助
 
-sepia 免費、不用帳號，每條規則背後的研究都一起公開。花錢的是證據本身：文獻調查委派給研究 agent，它們讀論文原文會消耗模型額度；每條規則改動上線前，都用真實模型實測（A/B 對照小說、跨平台的端到端審查）。贊助用來支付這些模型額度，以及維護時間。如果 sepia 讓你寫的東西讀起來更好，歡迎在 Patreon 上支持。
+sepia 免費，不需要帳號。每條規則背後的研究也都是公開的。專案的實際開銷只有維護時間與兩種模型額度：委派研究 agent 讀論文原文做文獻調查，以及規則改動發布前用真實模型實測 A/B 對照小說與跨平台端到端審查。歡迎前往 Patreon 贊助支持。
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -177,7 +177,7 @@ sepia/
 
 ## 贊助
 
-sepia 免費、不用帳號，每條規則背後的研究都一起公開。花錢的是把它做得可信這件事：每次發版都在多個平台上用真實模型跑驗證，行為測試每次推上 main 都會消耗模型 token，證據清單只靠讀論文原文增長，不靠摘要。贊助用來支付這些模型與 CI 費用，以及維護時間。如果 sepia 讓你寫的東西讀起來更好，歡迎在 Patreon 上支持。
+sepia 免費、不用帳號，每條規則背後的研究都一起公開。花錢的是證據本身：文獻調查委派給研究 agent，它們讀論文原文會消耗模型額度；每條規則改動上線前，都用真實模型實測（A/B 對照小說、跨平台的端到端審查）。贊助用來支付這些模型額度，以及維護時間。如果 sepia 讓你寫的東西讀起來更好，歡迎在 Patreon 上支持。
 
 [![Support sepia on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 


### PR DESCRIPTION
Adds `.github/FUNDING.yml` (`patreon: Nanako0129`, same as pilotfish / coralline / TokenBar-Native) and a Support section before License in the three READMEs, in TokenBar-Native's shape. The paragraph names the costs that actually exist here: model quota spent by the research agents that read papers in primary form for the evidence ledger, model quota spent on live test runs (A/B stories, cross-platform end-to-end reviews) before a rule ships, and maintainer time. It makes no CI claim (CI runs on GitHub's free tier) and no claim about features or outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXruziEKsmyqxRyni8JmkU