### PR TITLE
Fix entry-count descriptions to match the five on-disk skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Nanako Tsai"
   },
-  "description": "De-AI writing package with the general Sepia router plus five separate entries: write, review, refactor, and recreate.",
+  "description": "De-AI writing package with the general Sepia router plus five separate entries: write, review, refactor, recreate, and hemingway.",
   "plugins": [
     {
       "name": "sepia",
       "source": "./",
-      "description": "Installs the general Sepia router plus five separate entries: sepia-write, sepia-review, sepia-refactor, and sepia-recreate."
+      "description": "Installs the general Sepia router plus five separate entries: sepia-write, sepia-review, sepia-refactor, sepia-recreate, and sepia-hemingway."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sepia",
   "version": "0.10.0",
-  "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
+  "description": "De-AI writing package with the general Sepia router plus five separate operation entries: write, review, refactor, recreate, and hemingway.",
   "author": {
     "name": "Nanako Tsai"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sepia",
   "version": "0.10.0",
-  "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate.",
+  "description": "De-AI writing package with the general Sepia router plus five separate operation entries: write, review, refactor, recreate, and hemingway.",
   "skills": "./skills/",
   "license": "MIT",
   "repository": "https://github.com/Nanako0129/sepia",

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "sepia",
-  "description": "De-AI writing package with the general Sepia router plus four separate operation entries: write, review, refactor, and recreate."
+  "description": "De-AI writing package with the general Sepia router plus five separate operation entries: write, review, refactor, recreate, and hemingway."
 }


### PR DESCRIPTION
skills/ has shipped sepia-hemingway since #168, so there are five entry skills, not four. The packaging manifests disagreed about this:

- plugin.json, .claude-plugin/plugin.json, .codex-plugin/plugin.json said 'four separate operation entries' and enumerated four (write/review/ refactor/recreate), omitting hemingway.
- .claude-plugin/marketplace.json said 'five separate entries' but also enumerated only four, both in its top-level description and in the plugins[0].description.

Make every description consistent: say 'five' and list hemingway in each enumeration. No version, source, or skill content changed — this is purely the description strings, split out from the larger WorkBuddy PR per the maintainer's request.